### PR TITLE
Add e2e test harness and CRD smoke test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Read these docs before making changes:
 ## Building and Testing
 
 - `make build` — build all binaries
-- `make test` — run tests (includes envtest setup, CRD generation)
+- `make unit` — run unit tests (includes envtest setup, CRD generation)
+- `make e2e` — run e2e tests (requires bink; uses `BINK_PATH` env var or PATH). `V=1` for verbose streaming output.
 - `make fmt` — run go fmt
 - `make vet` — run go vet
 - `make lint` — run golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,17 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-.PHONY: test
-test: manifests generate setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test ./...
+.PHONY: unit
+unit: manifests generate setup-envtest ## Run unit tests (envtest).
+	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $$(go list ./... | grep -v /test/e2e)
+
+.PHONY: e2e
+e2e: manifests generate ## Run e2e tests (requires bink). V=1 for verbose.
+# NB: we `cd` here instead of passing a package path to `go test` so that `-v`
+# actually gives us streaming output (otherwise, it spawns a subprocess for
+# each package, even though we just have one here--but I really like streaming
+# output...).
+	cd test/e2e && go test -timeout 10m -count=1 $(if $(V),-v) .
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -55,7 +55,7 @@ Set up the bink-based e2e test infrastructure used by all subsequent milestones.
 Each e2e test gets its own bink cluster for full isolation and potential for
 parallelization.
 
-### 2a. Harness infrastructure
+### 2a. Harness infrastructure ✅
 
 Create `test/e2e/` with a helper package that provides a single entry
 point:
@@ -84,13 +84,13 @@ memory) and can be extended as needed by later milestones.
 - Builds a controller-runtime client
 - Registers `t.Cleanup` → `bink cluster stop --remove-data`
 
-### 2b. Smoke test
+### 2b. Smoke test ✅
 
 First e2e test: create a BootcNodePool and BootcNode, verify they are
 accepted and retrievable. Validates both the harness and the CRDs on
 a real cluster.
 
-### Validation
+### Validation ✅
 
 - Run the smoke test, verify it passes end-to-end.
 - Verify the cluster is torn down after test completes (including on

--- a/internal/controller/crd_test.go
+++ b/internal/controller/crd_test.go
@@ -26,14 +26,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
+	testutil "github.com/jlebon/bootc-operator/test/util"
+)
+
+// Test constants for image refs and digests.
+const (
+	testImageTaggedRef = "quay.io/example/myos:latest"
+
+	testDigestA         = "sha256:06f961b802bc46ee168555f066d28f4f0e9afdf3f88174c1ee6f9de004fc30a0" // "A"
+	testDigestB         = "sha256:c0cde77fa8fef97d476c10aad3d2d54fcc2f336140d073651c2dcccf1e379fd6" // "B"
+	testDigestC         = "sha256:12f37a8a84034d3e623d726fe10e5031f4df997ac13f4d5571b5a90c41fb84fe" // "C"
+	testImageDigestRefA = "quay.io/example/myos@" + testDigestA
+	testImageDigestRefB = "quay.io/example/myos@" + testDigestB
+	testImageDigestRefC = "quay.io/example/myos@" + testDigestC
+
+	testSecretName = "my-pull-secret"
+	testSecretNS   = "bootc-operator"
+	testSecretHash = "sha256:b37e50cedcd3e3f1ff64f4afc0422084ae694253cf399326868e07a35f4a45fb" // "secret"
 )
 
 func TestBootcNodePoolCRD(t *testing.T) {
 	ctx := context.Background()
 
-	pool := NewTestPool("workers",
-		WithRebootPolicy(bootcv1alpha1.RebootPolicyAllowSoftReboot),
-		WithPullSecret(testSecretName, testSecretNS),
+	pool := testutil.NewPool("workers", testImageTaggedRef,
+		testutil.WithRebootPolicy(bootcv1alpha1.RebootPolicyAllowSoftReboot),
+		testutil.WithPullSecret(testSecretName, testSecretNS),
 	)
 
 	// Save the spec before Create, which mutates pool in-place with
@@ -113,8 +130,8 @@ func TestBootcNodePoolCRD(t *testing.T) {
 func TestBootcNodeCRD(t *testing.T) {
 	ctx := context.Background()
 
-	node := NewTestNode("worker-1",
-		WithNodePullSecret(testSecretName, testSecretNS, testSecretHash),
+	node := testutil.NewNode("worker-1", testImageDigestRefA,
+		testutil.WithNodePullSecret(testSecretName, testSecretNS, testSecretHash),
 	)
 
 	// Save the spec before Create, which mutates node in-place.
@@ -200,8 +217,8 @@ func TestBootcNodeCRD(t *testing.T) {
 func TestBootcNodePoolEnumValidation(t *testing.T) {
 	ctx := context.Background()
 
-	pool := NewTestPool("invalid-reboot-policy",
-		WithRebootPolicy("Invalid"),
+	pool := testutil.NewPool("invalid-reboot-policy", testImageTaggedRef,
+		testutil.WithRebootPolicy("Invalid"),
 	)
 	if err := k8sClient.Create(ctx, pool); err == nil {
 		k8sClient.Delete(ctx, pool)
@@ -212,7 +229,7 @@ func TestBootcNodePoolEnumValidation(t *testing.T) {
 func TestBootcNodeEnumValidation(t *testing.T) {
 	ctx := context.Background()
 
-	node := NewTestNode("invalid-image-state")
+	node := testutil.NewNode("invalid-image-state", testImageDigestRefA)
 	node.Spec.DesiredImageState = "Invalid"
 	if err := k8sClient.Create(ctx, node); err == nil {
 		k8sClient.Delete(ctx, node)
@@ -223,8 +240,7 @@ func TestBootcNodeEnumValidation(t *testing.T) {
 func TestBootcNodePoolMinLengthValidation(t *testing.T) {
 	ctx := context.Background()
 
-	pool := NewTestPool("empty-image-ref")
-	pool.Spec.Image.Ref = ""
+	pool := testutil.NewPool("empty-image-ref", "")
 	if err := k8sClient.Create(ctx, pool); err == nil {
 		k8sClient.Delete(ctx, pool)
 		t.Fatal("Expected creation with empty image.ref to fail, but it succeeded")
@@ -234,8 +250,7 @@ func TestBootcNodePoolMinLengthValidation(t *testing.T) {
 func TestBootcNodeMinLengthValidation(t *testing.T) {
 	ctx := context.Background()
 
-	node := NewTestNode("empty-desired-image")
-	node.Spec.DesiredImage = ""
+	node := testutil.NewNode("empty-desired-image", "")
 	if err := k8sClient.Create(ctx, node); err == nil {
 		k8sClient.Delete(ctx, node)
 		t.Fatal("Expected creation with empty desiredImage to fail, but it succeeded")

--- a/test/e2e/crd_smoke_test.go
+++ b/test/e2e/crd_smoke_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
+	"github.com/jlebon/bootc-operator/test/e2e/e2eutil"
+	testutil "github.com/jlebon/bootc-operator/test/util"
+)
+
+// This is a simple "e2e" test which just tests CRD round-trips for now. We'll
+// nuke it or enhance it with more e2e-worthy flows once we have more of the
+// controller and daemon implemented.
+//
+// Note more comprehensive CRD round-trip tests exist in the unit tests.
+func TestCRDSmoke(t *testing.T) {
+	env := e2eutil.New(t)
+
+	ctx := context.Background()
+
+	t.Run("BootcNodePool", func(t *testing.T) {
+		pool := testutil.NewPool("smoke-pool", "quay.io/example/myos:latest")
+
+		if err := env.Client.Create(ctx, pool); err != nil {
+			t.Fatalf("Failed to create BootcNodePool: %v", err)
+		}
+
+		got := &bootcv1alpha1.BootcNodePool{}
+		if err := env.Client.Get(ctx, client.ObjectKeyFromObject(pool), got); err != nil {
+			t.Fatalf("Failed to get BootcNodePool: %v", err)
+		}
+		if got.Spec.Image.Ref != "quay.io/example/myos:latest" {
+			t.Errorf("image.ref = %q, want %q", got.Spec.Image.Ref, "quay.io/example/myos:latest")
+		}
+
+		if err := env.Client.Delete(ctx, pool); err != nil {
+			t.Fatalf("Failed to delete BootcNodePool: %v", err)
+		}
+	})
+
+	t.Run("BootcNode", func(t *testing.T) {
+		node := testutil.NewNode("smoke-node", "quay.io/example/myos@sha256:abc123")
+
+		if err := env.Client.Create(ctx, node); err != nil {
+			t.Fatalf("Failed to create BootcNode: %v", err)
+		}
+
+		got := &bootcv1alpha1.BootcNode{}
+		if err := env.Client.Get(ctx, client.ObjectKeyFromObject(node), got); err != nil {
+			t.Fatalf("Failed to get BootcNode: %v", err)
+		}
+		if got.Spec.DesiredImage != "quay.io/example/myos@sha256:abc123" {
+			t.Errorf("desiredImage = %q, want %q", got.Spec.DesiredImage, "quay.io/example/myos@sha256:abc123")
+		}
+		if got.Spec.DesiredImageState != bootcv1alpha1.DesiredImageStateStaged {
+			t.Errorf("desiredImageState = %q, want %q", got.Spec.DesiredImageState, bootcv1alpha1.DesiredImageStateStaged)
+		}
+
+		if err := env.Client.Delete(ctx, node); err != nil {
+			t.Fatalf("Failed to delete BootcNode: %v", err)
+		}
+	})
+}

--- a/test/e2e/e2eutil/env.go
+++ b/test/e2e/e2eutil/env.go
@@ -1,0 +1,311 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package e2eutil provides helpers for running end-to-end tests against
+// bink-managed Kubernetes clusters. Each test gets its own cluster for
+// full isolation.
+package e2eutil
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
+)
+
+// config holds resolved settings for the test cluster.
+type config struct {
+	memory int
+}
+
+// Option configures how the test cluster is created.
+type Option func(*config)
+
+// binkPath is resolved once on first use via resolveBinkPath.
+var (
+	binkPath     string
+	binkPathOnce sync.Once
+)
+
+// Env holds a live cluster context for a single e2e test.
+type Env struct {
+	// Client is a controller-runtime client with the bootc CRD scheme
+	// registered. Ready to create/get/list CRD objects.
+	Client client.Client
+
+	// Kubeconfig is the path to the kubeconfig file for this cluster.
+	Kubeconfig string
+
+	// Cluster is the bink cluster name.
+	Cluster string
+}
+
+// New creates a bink cluster, deploys the operator manifests, and
+// returns an Env ready for testing. The cluster is torn down
+// automatically when the test ends (including on failure).
+func New(t *testing.T, opts ...Option) *Env {
+	t.Helper()
+
+	cfg := config{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	resolveBinkPath(t)
+	clusterName := generateClusterName(t)
+
+	// Find the project root (where config/default/ lives).
+	projectRoot, err := findProjectRoot()
+	if err != nil {
+		t.Fatalf("finding project root: %v", err)
+	}
+
+	startCluster(t, clusterName, cfg.memory)
+
+	// Register cleanup early so the cluster is torn down even if
+	// subsequent steps fail.
+	t.Cleanup(func() {
+		stopCluster(t, clusterName)
+	})
+
+	kubeconfigPath := exposeAPI(t, clusterName)
+	applyManifests(t, kubeconfigPath, projectRoot)
+	k8sClient := buildClient(t, kubeconfigPath)
+	waitForNodeReady(t, k8sClient, "node1")
+
+	return &Env{
+		Client:     k8sClient,
+		Kubeconfig: kubeconfigPath,
+		Cluster:    clusterName,
+	}
+}
+
+// WithMemory sets the VM memory in MB. If not set, bink's default is used.
+func WithMemory(mb int) Option {
+	return func(c *config) {
+		c.memory = mb
+	}
+}
+
+// resolveBinkPath locates the bink binary on first call (via BINK_PATH
+// env var or PATH lookup) and caches the result.
+func resolveBinkPath(t *testing.T) {
+	t.Helper()
+
+	var resolveErr error
+	binkPathOnce.Do(func() {
+		if p := os.Getenv("BINK_PATH"); p != "" {
+			if _, err := os.Stat(p); err != nil {
+				resolveErr = fmt.Errorf("BINK_PATH=%q not found: %w", p, err)
+				return
+			}
+			binkPath = p
+			return
+		}
+		if p, err := exec.LookPath("bink"); err != nil {
+			resolveErr = fmt.Errorf("PATH lookup failed: %w", err)
+		} else {
+			binkPath = p
+		}
+	})
+
+	if binkPath == "" {
+		// Since this is only set when Once is triggered, we implicitly only
+		// log the actual failure once here. Other calls would get the generic
+		// error. I don't think that's a problem.
+		if resolveErr != nil {
+			t.Log(resolveErr)
+		}
+		t.Fatal("bink binary not found (set BINK_PATH or add to PATH)")
+	}
+}
+
+// generateClusterName creates a unique cluster name for test isolation.
+func generateClusterName(t *testing.T) string {
+	t.Helper()
+
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("generating random cluster name: %v", err)
+	}
+	return "e2e-" + hex.EncodeToString(b)
+}
+
+// findProjectRoot walks up from the working directory looking for go.mod.
+func findProjectRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not find go.mod in any parent directory")
+		}
+		dir = parent
+	}
+}
+
+// startCluster runs `bink cluster start`.
+func startCluster(t *testing.T, clusterName string, memory int) {
+	t.Helper()
+
+	args := []string{"cluster", "start",
+		"--cluster-name", clusterName,
+		"--api-port", "0",
+	}
+	if memory > 0 {
+		args = append(args, "--memory", fmt.Sprintf("%d", memory))
+	}
+
+	t.Logf("Starting bink cluster %q...", clusterName)
+	if err := runBink(t, args...); err != nil {
+		t.Fatalf("starting cluster: %v", err)
+	}
+}
+
+// stopCluster runs `bink cluster stop --remove-data`.
+func stopCluster(t *testing.T, clusterName string) {
+	t.Logf("Tearing down bink cluster %q...", clusterName)
+	if err := runBink(t, "cluster", "stop", "--remove-data", "--cluster-name", clusterName); err != nil {
+		// Log but don't fail — we're in cleanup.
+		t.Logf("WARNING: failed to stop cluster %q: %v", clusterName, err)
+	}
+}
+
+// exposeAPI runs `bink api expose` and returns the kubeconfig path.
+func exposeAPI(t *testing.T, clusterName string) string {
+	t.Helper()
+	t.Logf("Exposing API for cluster %q...", clusterName)
+
+	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := runBink(t, "api", "expose",
+		"--cluster-name", clusterName,
+		"--kubeconfig", kubeconfigPath,
+	); err != nil {
+		t.Fatalf("exposing API: %v", err)
+	}
+	return kubeconfigPath
+}
+
+// applyManifests runs `kubectl apply -k config/default/` to deploy the
+// operator manifests (CRDs, RBAC, manager Deployment).
+func applyManifests(t *testing.T, kubeconfigPath, projectRoot string) {
+	t.Helper()
+	t.Log("Applying operator manifests (config/default/)...")
+
+	kubectl, err := exec.LookPath("kubectl")
+	if err != nil {
+		t.Fatal("kubectl not found on PATH")
+	}
+
+	// We shell out to kubectl rather than using a Go client because
+	// kubectl handles kustomize rendering and server-side apply in one
+	// shot — reimplementing that in Go would be significant.
+	kustomizeDir := filepath.Join(projectRoot, "config", "default")
+	cmd := exec.Command(kubectl, "apply",
+		"--kubeconfig", kubeconfigPath,
+		"-k", kustomizeDir,
+		"--server-side",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("applying manifests: %v", err)
+	}
+}
+
+// buildClient creates a controller-runtime client from the kubeconfig
+// with the bootc CRD scheme registered.
+func buildClient(t *testing.T, kubeconfigPath string) client.Client {
+	t.Helper()
+
+	if err := bootcv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("adding bootc scheme: %v", err)
+	}
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		t.Fatalf("building rest config from kubeconfig: %v", err)
+	}
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		t.Fatalf("creating controller-runtime client: %v", err)
+	}
+
+	return c
+}
+
+// waitForNodeReady polls until the named node has condition Ready=True.
+func waitForNodeReady(t *testing.T, c client.Client, nodeName string) {
+	t.Helper()
+	t.Logf("Waiting for node %q to be Ready...", nodeName)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for node %q to become Ready", nodeName)
+		case <-ticker.C:
+			node := &corev1.Node{}
+			if err := c.Get(ctx, client.ObjectKey{Name: nodeName}, node); err != nil {
+				t.Logf("  node %q not found yet: %v", nodeName, err)
+				continue
+			}
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+					t.Logf("  node %q is Ready", nodeName)
+					return
+				}
+			}
+		}
+	}
+}
+
+// runBink executes a bink command and returns any error.
+func runBink(t *testing.T, args ...string) error {
+	t.Helper()
+
+	if binkPath == "" {
+		panic("runBink called before resolveBinkPath")
+	}
+	cmd := exec.Command(binkPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/test/util/builders.go
+++ b/test/util/builders.go
@@ -14,36 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller
+// Package testutil provides shared test helpers for building bootc CRD
+// objects with functional options.
+package testutil
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
 )
 
-// Test constants for image refs and digests.
-const (
-	testImageTaggedRef = "quay.io/example/myos:latest"
-
-	testDigestA         = "sha256:06f961b802bc46ee168555f066d28f4f0e9afdf3f88174c1ee6f9de004fc30a0" // "A"
-	testDigestB         = "sha256:c0cde77fa8fef97d476c10aad3d2d54fcc2f336140d073651c2dcccf1e379fd6" // "B"
-	testDigestC         = "sha256:12f37a8a84034d3e623d726fe10e5031f4df997ac13f4d5571b5a90c41fb84fe" // "C"
-	testImageDigestRefA = "quay.io/example/myos@" + testDigestA
-	testImageDigestRefB = "quay.io/example/myos@" + testDigestB
-	testImageDigestRefC = "quay.io/example/myos@" + testDigestC
-
-	testSecretName = "my-pull-secret"
-	testSecretNS   = "bootc-operator"
-	testSecretHash = "sha256:b37e50cedcd3e3f1ff64f4afc0422084ae694253cf399326868e07a35f4a45fb" // "secret"
-)
-
-// PoolOption configures a BootcNodePool for testing.
+// PoolOption configures a BootcNodePool.
 type PoolOption func(*bootcv1alpha1.BootcNodePool)
 
-// NewTestPool creates a BootcNodePool with sensible defaults for
-// testing. Override any field via functional options.
-func NewTestPool(name string, opts ...PoolOption) *bootcv1alpha1.BootcNodePool {
+// NewPool creates a BootcNodePool with the given name and image ref.
+// A default worker node selector is applied. Override fields via
+// functional options.
+func NewPool(name, imageRef string, opts ...PoolOption) *bootcv1alpha1.BootcNodePool {
 	pool := &bootcv1alpha1.BootcNodePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -55,7 +43,7 @@ func NewTestPool(name string, opts ...PoolOption) *bootcv1alpha1.BootcNodePool {
 				},
 			},
 			Image: bootcv1alpha1.ImageSpec{
-				Ref: testImageTaggedRef,
+				Ref: imageRef,
 			},
 		},
 	}
@@ -85,18 +73,29 @@ func WithPullSecret(name, namespace string) PoolOption {
 	}
 }
 
-// NodeOption configures a BootcNode for testing.
+// WithMaxUnavailable sets the rollout max unavailable field.
+func WithMaxUnavailable(v intstr.IntOrString) PoolOption {
+	return func(pool *bootcv1alpha1.BootcNodePool) {
+		if pool.Spec.Rollout == nil {
+			pool.Spec.Rollout = &bootcv1alpha1.RolloutSpec{}
+		}
+		pool.Spec.Rollout.MaxUnavailable = &v
+	}
+}
+
+// NodeOption configures a BootcNode.
 type NodeOption func(*bootcv1alpha1.BootcNode)
 
-// NewTestNode creates a BootcNode with sensible defaults for testing.
-// Override any field via functional options.
-func NewTestNode(name string, opts ...NodeOption) *bootcv1alpha1.BootcNode {
+// NewNode creates a BootcNode with the given name and desired image.
+// DesiredImageState defaults to Staged. Override fields via functional
+// options.
+func NewNode(name, desiredImage string, opts ...NodeOption) *bootcv1alpha1.BootcNode {
 	node := &bootcv1alpha1.BootcNode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: bootcv1alpha1.BootcNodeSpec{
-			DesiredImage:      testImageDigestRefA,
+			DesiredImage:      desiredImage,
 			DesiredImageState: bootcv1alpha1.DesiredImageStateStaged,
 		},
 	}


### PR DESCRIPTION
This is where things get interesting CI-wise!

We hook up a test harness which uses bink. For now it's minimal but does
the fundamentals: it handles the cluster lifecycle and the test is just
handed a controller-runtime client.

Add a basic smoke test to exercise all this which just creates a
BootcNodePool and BootcNode and verifies they round-trip correctly.
That's not very different from the envtest version of this, but we'll
build on it in future milestones!

Assisted-by: Pi (Claude Opus 4.6)