### PR TITLE
Makefile: add deploy-bink, rework deploy, decouple e2e

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,10 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: bink
+          path: /usr/local/bin
+
+      - name: Make bink executable
+        run: chmod +x /usr/local/bin/bink
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -111,8 +115,4 @@ jobs:
         run: systemctl --user start podman.socket
 
       - name: Run e2e tests
-        run: |
-          chmod +x bink
-          make e2e V=1
-        env:
-          BINK_PATH: ${{ github.workspace }}/bink
+        run: make buildimg deploy-bink e2e V=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 *.out
+kubeconfig-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ Read these docs before making changes:
 
 - `make build` — build all binaries
 - `make unit` — run unit tests (includes envtest setup, CRD generation). `V=1` for verbose. `RUN=<regex>` to filter.
-- `make e2e` — run e2e tests (requires bink; uses `BINK_PATH` env var or PATH). `V=1` for verbose streaming output. `RUN=<regex>` to filter.
+- `make deploy-bink` — deploy operator to a bink cluster (idempotent; requires `make buildimg` first)
+- `make teardown-bink` — tear down the bink cluster
+- `make e2e` — run e2e tests (requires `make deploy-bink` first). `V=1` for verbose streaming output. `RUN=<regex>` to filter.
 - `make fmt` — run go fmt
 - `make vet` — run go vet
 - `make lint` — run golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # Image URL to use all building/pushing image targets
 IMG ?= bootc-operator:dev
 CONTAINER_TOOL ?= podman
+# Bink cluster settings. deploy-bink and e2e share the same cluster by default.
+# To use a separate dev cluster: make deploy-bink BINK_CLUSTER_NAME=dev
+BINK_CLUSTER_NAME ?= e2e
+KUBECONFIG_BINK ?= ./kubeconfig-$(BINK_CLUSTER_NAME)
 # YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
 YEAR ?= $(shell date +%Y)
 
@@ -41,12 +45,14 @@ unit: manifests generate setup-envtest ## Run unit tests (envtest). V=1 for verb
 	KUBEBUILDER_ASSETS="$(shell "$(ENVTEST)" use $(ENVTEST_K8S_VERSION) --bin-dir "$(LOCALBIN)" -p path)" go test $(if $(V),-v) $(if $(RUN),-run $(RUN)) $$(go list ./... | grep -v /test/e2e)
 
 .PHONY: e2e
-e2e: manifests generate buildimg ## Run e2e tests (requires bink). V=1 for verbose. RUN=<regex> to filter.
+e2e: ## Run e2e tests (requires: make deploy-bink). V=1 for verbose. RUN=<regex> to filter.
 # NB: we `cd` here instead of passing a package path to `go test` so that `-v`
 # actually gives us streaming output (otherwise, it spawns a subprocess for
 # each package, even though we just have one here--but I really like streaming
 # output...).
-	cd test/e2e && IMG=$(IMG) go test -timeout 10m -count=1 $(if $(V),-v) $(if $(RUN),-run $(RUN)) .
+	cd test/e2e && KUBECONFIG=$(abspath $(KUBECONFIG_BINK)) BINK_CLUSTER_NAME=$(BINK_CLUSTER_NAME) \
+		$(if $(BINK_NODE_IMAGE),BINK_NODE_IMAGE=$(BINK_NODE_IMAGE)) \
+		go test -timeout 10m -count=1 $(if $(V),-v) $(if $(RUN),-run $(RUN)) .
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter.
@@ -97,6 +103,26 @@ deploy: manifests kustomize yq ## Deploy controller to the K8s cluster specified
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -
+
+# In-cluster image used by deploy-bink after pushing to the bink registry.
+IMG_BINK ?= registry.cluster.local:5000/bootc-operator:e2e
+
+.PHONY: deploy-bink
+deploy-bink: kustomize ## Deploy to a bink cluster (idempotent).
+	bink registry start
+	podman push --tls-verify=false $(IMG) localhost:5000/bootc-operator:e2e
+	bink cluster list 2>&1 | grep -qw $(BINK_CLUSTER_NAME) || \
+		bink cluster start --cluster-name $(BINK_CLUSTER_NAME) --node-name controller --api-port 0 --expose $(KUBECONFIG_BINK) \
+		$(if $(BINK_NODE_IMAGE),--node-image $(BINK_NODE_IMAGE))
+	kubectl --kubeconfig $(KUBECONFIG_BINK) wait --for=condition=Ready node/controller --timeout=5m
+	$(MAKE) deploy KUBECONFIG=$(abspath $(KUBECONFIG_BINK)) IMG=$(IMG_BINK)
+	kubectl --kubeconfig $(KUBECONFIG_BINK) -n bootc-operator rollout restart deployment/bootc-operator-controller-manager
+	kubectl --kubeconfig $(KUBECONFIG_BINK) -n bootc-operator rollout status deployment/bootc-operator-controller-manager --timeout=3m
+
+.PHONY: teardown-bink
+teardown-bink: ## Tear down the bink cluster.
+	bink cluster stop --remove-data --cluster-name $(BINK_CLUSTER_NAME)
+	rm -f $(KUBECONFIG_BINK)
 
 ##@ Dependencies
 

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	"$(KUSTOMIZE)" build config/crd | "$(KUBECTL)" delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG}
-	cd config/daemon && "$(KUSTOMIZE)" edit set image controller=${IMG}
-	"$(KUSTOMIZE)" build config/default | "$(KUBECTL)" apply -f -
+deploy: manifests kustomize yq ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+	"$(KUSTOMIZE)" build config/default | \
+		"$(YQ)" '(select(.kind == "Deployment") | .spec.template.spec.containers[] | select(.name == "manager")).image = "$(IMG)"' | \
+		"$(YQ)" '(select(.kind == "DaemonSet") | .spec.template.spec.containers[] | select(.name == "daemon")).image = "$(IMG)"' | \
+		"$(KUBECTL)" apply --server-side -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
@@ -108,10 +109,12 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
+YQ ?= $(LOCALBIN)/yq
 
 KUSTOMIZE_VERSION ?= v5.8.1
 CONTROLLER_TOOLS_VERSION ?= v0.20.1
 GOLANGCI_LINT_VERSION ?= v2.11.4
+YQ_VERSION ?= v4.53.2
 
 # ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; \
@@ -149,6 +152,11 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+.PHONY: yq
+yq: $(YQ) ## Download yq locally if necessary.
+$(YQ): $(LOCALBIN)
+	$(call go-install-tool,$(YQ),github.com/mikefarah/yq/v4,$(YQ_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,6 +53,10 @@ spec:
       #             operator: In
       #             values:
       #               - linux
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       securityContext:
         # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
         # This ensures that deployments meet the highest security requirements for Kubernetes.

--- a/test/e2e/controller_test.go
+++ b/test/e2e/controller_test.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"context"
-	"maps"
 	"testing"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 
 	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
 	"github.com/jlebon/bootc-operator/test/e2e/e2eutil"
-	testutil "github.com/jlebon/bootc-operator/test/util"
 )
 
 const (
@@ -23,51 +21,42 @@ const (
 	pollInterval = 2 * time.Second
 )
 
-// TestControllerMembership deploys the controller in a bink cluster,
-// creates a BootcNodePool selecting the worker node, and verifies that
-// a BootcNode is created and the node is labeled bootc.dev/managed.
+// TestControllerMembership provisions a worker node, creates a
+// BootcNodePool selecting it, and verifies that a BootcNode is created
+// and the node is labeled bootc.dev/managed.
 func TestControllerMembership(t *testing.T) {
 	g := NewWithT(t)
 	g.SetDefaultEventuallyTimeout(pollTimeout)
 	g.SetDefaultEventuallyPollingInterval(pollInterval)
 
 	env := e2eutil.New(t)
+	nodeName := env.AddNode(t)
 
 	ctx := context.Background()
 
-	// The bink cluster has a node called "node1". Label it as a worker so it
-	// matches our pool's default nodeSelector. XXX: lower this down to bink?
-	var node corev1.Node
-	g.Expect(env.Client.Get(ctx, client.ObjectKey{Name: "node1"}, &node)).To(Succeed())
-	patch := client.StrategicMergeFrom(node.DeepCopy())
-	if node.Labels == nil {
-		node.Labels = map[string]string{}
-	}
-	maps.Copy(node.Labels, testutil.WorkerLabels())
-	g.Expect(env.Client.Patch(ctx, &node, patch)).To(Succeed())
-
-	// Create a pool with a digest ref.
+	// Create a pool selecting this test's nodes.
 	imageRef := "quay.io/example/myos@sha256:06f961b802bc46ee168555f066d28f4f0e9afdf3f88174c1ee6f9de004fc30a0"
-	pool := testutil.NewPool("e2e-workers", imageRef, testutil.WithWorkerSelector())
+	pool := env.NewPool("workers", imageRef)
 	g.Expect(env.Client.Create(ctx, pool)).To(Succeed())
 
-	// Wait for BootcNode to appear for node1.
+	// Wait for BootcNode to appear for the worker.
 	var bn bootcv1alpha1.BootcNode
 	g.Eventually(func() error {
-		return env.Client.Get(ctx, client.ObjectKey{Name: "node1"}, &bn)
+		return env.Client.Get(ctx, client.ObjectKey{Name: nodeName}, &bn)
 	}).Should(Succeed())
 
 	// Verify ownerReference.
 	owner := metav1.GetControllerOf(&bn)
 	g.Expect(owner).NotTo(BeNil())
-	g.Expect(owner.Name).To(Equal("e2e-workers"))
+	g.Expect(owner.Name).To(Equal(pool.Name))
 
 	// Verify desiredImage.
 	g.Expect(bn.Spec.DesiredImage).To(Equal(imageRef))
 
-	// Verify node1 has the managed label.
+	// Verify the worker has the managed label.
+	var node corev1.Node
 	g.Eventually(func() (map[string]string, error) {
-		err := env.Client.Get(ctx, client.ObjectKey{Name: "node1"}, &node)
+		err := env.Client.Get(ctx, client.ObjectKey{Name: nodeName}, &node)
 		return node.Labels, err
 	}).Should(HaveKey(bootcv1alpha1.LabelManaged))
 
@@ -83,7 +72,7 @@ func TestControllerMembership(t *testing.T) {
 		)
 		return pods.Items, err
 	}).Should(ConsistOf(And(
-		HaveField("Spec.NodeName", "node1"),
+		HaveField("Spec.NodeName", nodeName),
 		HaveField("Status.Phase", corev1.PodRunning),
-	)), "expected exactly one running daemon pod on node1")
+	)), "expected exactly one running daemon pod on %s", nodeName)
 }

--- a/test/e2e/crd_smoke_test.go
+++ b/test/e2e/crd_smoke_test.go
@@ -14,10 +14,8 @@ import (
 	testutil "github.com/jlebon/bootc-operator/test/util"
 )
 
-// This is a simple "e2e" test which just tests CRD round-trips for now. We'll
-// nuke it or enhance it with more e2e-worthy flows once we have more of the
-// controller and daemon implemented.
-//
+// TestCRDSmoke verifies CRD round-trips. We'll nuke it or enhance it with more
+// e2e-worthy flows once we have more of the controller and daemon implemented.
 // Note more comprehensive CRD round-trip tests exist in the unit tests.
 func TestCRDSmoke(t *testing.T) {
 	env := e2eutil.New(t)
@@ -27,29 +25,26 @@ func TestCRDSmoke(t *testing.T) {
 	t.Run("BootcNodePool", func(t *testing.T) {
 		g := NewWithT(t)
 
-		pool := testutil.NewPool("smoke-pool", "quay.io/example/myos:latest", testutil.WithWorkerSelector())
-
+		pool := env.NewPool("pool", "quay.io/example/myos:latest")
 		g.Expect(env.Client.Create(ctx, pool)).To(Succeed())
 
 		got := &bootcv1alpha1.BootcNodePool{}
 		g.Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(pool), got)).To(Succeed())
 		g.Expect(got.Spec.Image.Ref).To(Equal("quay.io/example/myos:latest"))
-
-		g.Expect(env.Client.Delete(ctx, pool)).To(Succeed())
 	})
 
 	t.Run("BootcNode", func(t *testing.T) {
 		g := NewWithT(t)
 
 		node := testutil.NewNode("smoke-node", "quay.io/example/myos@sha256:abc123")
-
 		g.Expect(env.Client.Create(ctx, node)).To(Succeed())
+		t.Cleanup(func() {
+			_ = env.Client.Delete(ctx, node)
+		})
 
 		got := &bootcv1alpha1.BootcNode{}
 		g.Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(node), got)).To(Succeed())
 		g.Expect(got.Spec.DesiredImage).To(Equal("quay.io/example/myos@sha256:abc123"))
 		g.Expect(got.Spec.DesiredImageState).To(Equal(bootcv1alpha1.DesiredImageStateStaged))
-
-		g.Expect(env.Client.Delete(ctx, node)).To(Succeed())
 	})
 }

--- a/test/e2e/e2eutil/env.go
+++ b/test/e2e/e2eutil/env.go
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package e2eutil provides helpers for running end-to-end tests against
-// bink-managed Kubernetes clusters. Each test gets its own cluster for
-// full isolation.
+// a bink-managed Kubernetes cluster. The cluster and operator are
+// expected to be already running (via `make deploy-bink`). Each test
+// provisions its own worker nodes for isolation.
 package e2eutil
 
 import (
@@ -12,345 +13,209 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"sync"
+	"strings"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega" //nolint:staticcheck
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
+	testutil "github.com/jlebon/bootc-operator/test/util"
 )
 
-// config holds resolved settings for the test cluster.
-type config struct {
-	memory int
-}
-
-// Option configures how the test cluster is created.
-type Option func(*config)
-
-// binkPath is resolved once on first use via resolveBinkPath.
-var (
-	binkPath     string
-	binkPathOnce sync.Once
+const (
+	// LabelE2ETest is applied to test-scoped resources (nodes, pools).
+	// Its value is the sanitized test name, used for both node
+	// selection and label-based cleanup.
+	LabelE2ETest = "bootc.dev/e2e-test"
 )
 
-// Env holds a live cluster context for a single e2e test.
+// Env holds a cluster context for a single e2e test. Each test creates
+// its own Env via New(t), so test-scoped state (like the test ID used
+// for node labeling and pool selectors) lives here.
 type Env struct {
 	// Client is a controller-runtime client with the bootc CRD scheme
-	// registered. Ready to create/get/list CRD objects.
+	// registered.
 	Client client.Client
 
-	// Kubeconfig is the path to the kubeconfig file for this cluster.
-	Kubeconfig string
+	// clusterName is the bink cluster name.
+	clusterName string
 
-	// Cluster is the bink cluster name.
-	Cluster string
+	// testID is the sanitized test name, used as the value for
+	// LabelE2ETest on nodes and in pool selectors.
+	testID string
+
+	// nodes tracks node names added via AddNode for cleanup.
+	nodes []string
 }
 
-// New creates a bink cluster, deploys the operator manifests, and
-// returns an Env ready for testing. The cluster is torn down
-// automatically when the test ends (including on failure).
-func New(t *testing.T, opts ...Option) *Env {
+// New connects to an existing bink cluster and returns an Env ready
+// for testing. The cluster must be running with the operator deployed
+// (via `make deploy-bink`).
+func New(t *testing.T) *Env {
 	t.Helper()
 
-	cfg := config{}
-	for _, o := range opts {
-		o(&cfg)
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	if kubeconfigPath == "" {
+		t.Fatal("KUBECONFIG must be set")
 	}
 
-	resolveBinkPath(t)
-	clusterName := generateClusterName(t)
-
-	// Find the project root (where config/default/ lives).
-	projectRoot, err := findProjectRoot()
-	if err != nil {
-		t.Fatalf("finding project root: %v", err)
+	clusterName := os.Getenv("BINK_CLUSTER_NAME")
+	if clusterName == "" {
+		t.Fatal("BINK_CLUSTER_NAME must be set")
 	}
-
-	startCluster(t, clusterName, cfg.memory)
-
-	// Register cleanup early so the cluster is torn down even if
-	// subsequent steps fail.
-	t.Cleanup(func() {
-		stopCluster(t, clusterName)
-	})
-
-	kubeconfigPath := exposeAPI(t, clusterName)
 
 	k8sClient := buildClient(t, kubeconfigPath)
-	waitForNodeReady(t, k8sClient, "node1")
 
-	pushControllerImage(t)
-	applyManifests(t, kubeconfigPath, projectRoot)
-	waitForControllerReady(t, k8sClient)
-
-	return &Env{
-		Client:     k8sClient,
-		Kubeconfig: kubeconfigPath,
-		Cluster:    clusterName,
+	env := &Env{
+		Client:      k8sClient,
+		clusterName: clusterName,
+		testID:      sanitizeTestName(t.Name()),
 	}
+
+	t.Cleanup(func() {
+		env.cleanup(t)
+	})
+
+	return env
 }
 
-// WithMemory sets the VM memory in MB. If not set, bink's default is used.
-func WithMemory(mb int) Option {
-	return func(c *config) {
+// NodeOption configures a node provisioned by AddNode.
+type NodeOption func(*nodeConfig)
+
+type nodeConfig struct {
+	memory int
+	labels map[string]string
+}
+
+// WithMemory sets the VM memory in MB for the node.
+func WithMemory(mb int) NodeOption {
+	return func(c *nodeConfig) {
 		c.memory = mb
 	}
 }
 
-// resolveBinkPath locates the bink binary on first call (via BINK_PATH
-// env var or PATH lookup) and caches the result.
-func resolveBinkPath(t *testing.T) {
-	t.Helper()
-
-	var resolveErr error
-	binkPathOnce.Do(func() {
-		if p := os.Getenv("BINK_PATH"); p != "" {
-			if _, err := os.Stat(p); err != nil {
-				resolveErr = fmt.Errorf("BINK_PATH=%q not found: %w", p, err)
-				return
-			}
-			binkPath = p
-			return
+// WithLabel adds a label to the provisioned node. This is in addition
+// to the LabelE2ETest label which is always applied.
+func WithLabel(key, value string) NodeOption {
+	return func(c *nodeConfig) {
+		if c.labels == nil {
+			c.labels = make(map[string]string)
 		}
-		if p, err := exec.LookPath("bink"); err != nil {
-			resolveErr = fmt.Errorf("PATH lookup failed: %w", err)
-		} else {
-			binkPath = p
-		}
-	})
-
-	if binkPath == "" {
-		// Since this is only set when Once is triggered, we implicitly only
-		// log the actual failure once here. Other calls would get the generic
-		// error. I don't think that's a problem.
-		if resolveErr != nil {
-			t.Log(resolveErr)
-		}
-		t.Fatal("bink binary not found (set BINK_PATH or add to PATH)")
+		c.labels[key] = value
 	}
 }
 
-// generateClusterName creates a unique cluster name for test isolation.
-func generateClusterName(t *testing.T) string {
+// AddNode provisions a worker node via bink, waits for it to be Ready,
+// labels it with LabelE2ETest, and registers cleanup to remove it.
+// Returns the node name.
+func (e *Env) AddNode(t *testing.T, opts ...NodeOption) string {
 	t.Helper()
 
-	b := make([]byte, 4)
-	if _, err := rand.Read(b); err != nil {
-		t.Fatalf("generating random cluster name: %v", err)
+	cfg := &nodeConfig{}
+	for _, o := range opts {
+		o(cfg)
 	}
-	return "e2e-" + hex.EncodeToString(b)
-}
 
-// findProjectRoot walks up from the working directory looking for go.mod.
-func findProjectRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("could not find go.mod in any parent directory")
-		}
-		dir = parent
-	}
-}
+	nodeName := e.generateNodeName(t)
 
-// startCluster runs `bink cluster start`.
-func startCluster(t *testing.T, clusterName string, memory int) {
-	t.Helper()
-
-	args := []string{"cluster", "start",
-		"--cluster-name", clusterName,
-		"--api-port", "0",
-	}
-	if memory > 0 {
-		args = append(args, "--memory", fmt.Sprintf("%d", memory))
+	// Provision the node.
+	args := []string{"node", "add", nodeName, "--cluster-name", e.clusterName, "--control-plane", "controller"}
+	if cfg.memory > 0 {
+		args = append(args, "--memory", fmt.Sprintf("%d", cfg.memory))
 	}
 	if img := os.Getenv("BINK_NODE_IMAGE"); img != "" {
 		args = append(args, "--node-image", img)
 	}
-
-	t.Logf("Starting bink cluster %q...", clusterName)
+	t.Logf("Adding node %q...", nodeName)
 	if err := runBink(t, args...); err != nil {
-		t.Fatalf("starting cluster: %v", err)
+		t.Fatalf("adding node %q: %v", nodeName, err)
 	}
+
+	e.nodes = append(e.nodes, nodeName)
+
+	// Wait for Ready.
+	waitForNodeReady(t, e.Client, nodeName)
+
+	// Label with test ID (replace with --label` once available:
+	// https://github.com/alicefr/bink/issues/23).
+	var node corev1.Node
+	if err := e.Client.Get(context.Background(), client.ObjectKey{Name: nodeName}, &node); err != nil {
+		t.Fatalf("getting node %q for labeling: %v", nodeName, err)
+	}
+	patch := client.StrategicMergeFrom(node.DeepCopy())
+	if node.Labels == nil {
+		node.Labels = map[string]string{}
+	}
+	node.Labels[LabelE2ETest] = e.testID
+	for k, v := range cfg.labels {
+		node.Labels[k] = v
+	}
+	if err := e.Client.Patch(context.Background(), &node, patch); err != nil {
+		t.Fatalf("labeling node %q: %v", nodeName, err)
+	}
+
+	return nodeName
 }
 
-// stopCluster runs `bink cluster stop --remove-data`.
-func stopCluster(t *testing.T, clusterName string) {
-	t.Logf("Tearing down bink cluster %q...", clusterName)
-	if err := runBink(t, "cluster", "stop", "--remove-data", "--cluster-name", clusterName); err != nil {
-		// Log but don't fail — we're in cleanup.
-		t.Logf("WARNING: failed to stop cluster %q: %v", clusterName, err)
+// NewPool creates a BootcNodePool with a test-scoped name and labels.
+// The pool is labeled with LabelE2ETest for cleanup. If no
+// WithNodeSelector option is provided, it defaults to selecting nodes
+// with LabelE2ETest (i.e. all nodes belonging to this test).
+func (e *Env) NewPool(suffix, imageRef string, opts ...testutil.PoolOption) *bootcv1alpha1.BootcNodePool {
+	defaults := []testutil.PoolOption{
+		testutil.WithLabel(LabelE2ETest, e.testID),
+		testutil.WithNodeSelector(e.TestLabels()),
 	}
+	allOpts := append(defaults, opts...)
+	return testutil.NewPool(e.testID+"-"+suffix, imageRef, allOpts...)
 }
 
-// exposeAPI runs `bink api expose` and returns the kubeconfig path.
-func exposeAPI(t *testing.T, clusterName string) string {
-	t.Helper()
-	t.Logf("Exposing API for cluster %q...", clusterName)
-
-	kubeconfigPath := filepath.Join(t.TempDir(), "kubeconfig")
-	if err := runBink(t, "api", "expose",
-		"--cluster-name", clusterName,
-		"--kubeconfig", kubeconfigPath,
-	); err != nil {
-		t.Fatalf("exposing API: %v", err)
-	}
-	return kubeconfigPath
+// TestLabels returns the label map identifying resources belonging to
+// this test. Use with testutil.WithNodeSelector() when overriding the
+// default node selector in NewPool.
+func (e *Env) TestLabels() map[string]string {
+	return map[string]string{LabelE2ETest: e.testID}
 }
 
-const (
-	// registryImage is the pullspec used to push to the bink registry
-	// from the host.
-	registryImage = "localhost:5000/bootc-operator:e2e"
-	// inClusterControllerRepo is the in-cluster registry repo for the
-	// controller image (without tag).
-	inClusterControllerRepo = "registry.cluster.local:5000/bootc-operator"
-	// inClusterControllerTag is the tag used for the controller image.
-	inClusterControllerTag = "e2e"
-)
-
-// controllerImagePushed tracks whether the image has already been pushed
-// for this test run. Multiple tests share the same image.
-var (
-	controllerImagePushed     bool
-	controllerImagePushedOnce sync.Once
-)
-
-// pushControllerImage pushes the pre-built controller image (from IMG
-// env var, set by the Makefile) to the bink registry. This is done once
-// per test run.
-func pushControllerImage(t *testing.T) {
-	t.Helper()
-
-	controllerImagePushedOnce.Do(func() {
-		srcImage := os.Getenv("IMG")
-		if srcImage == "" {
-			t.Fatal("IMG env var not set (run via 'make e2e')")
-		}
-
-		t.Logf("Pushing %s to %s...", srcImage, registryImage)
-		cmd := exec.Command("podman", "push", "--tls-verify=false", srcImage, registryImage)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			t.Fatalf("pushing controller image: %v", err)
-		}
-
-		controllerImagePushed = true
-	})
-
-	if !controllerImagePushed {
-		t.Fatal("controller image push failed in another test")
-	}
-}
-
-// applyManifests applies the operator manifests with the image set to
-// the in-cluster registry pullspec. It creates a temporary kustomize
-// overlay that references the project's config/default via a symlink
-// and adds an image override. Both the controller and daemon use the
-// same image; the manifests select the right binary via command.
-func applyManifests(t *testing.T, kubeconfigPath, projectRoot string) {
-	t.Helper()
-	t.Logf("Applying operator manifests with image %s...", inClusterControllerRepo+":"+inClusterControllerTag)
-
-	kubectl, err := exec.LookPath("kubectl")
-	if err != nil {
-		t.Fatal("kubectl not found on PATH")
-	}
-
-	// Build a temp dir with an overlay kustomization that references
-	// the project's config/default via a relative path. The layout is:
-	//   <tmpdir>/config -> <projectRoot>/config  (symlink)
-	//   <tmpdir>/overlay/kustomization.yaml      (overlay)
-	// So the overlay can use "../config/default" as a resource (because
-	// kustomize doesn't allow absolute paths for resources).
-	tmpdir := t.TempDir()
-
-	absConfig, _ := filepath.Abs(filepath.Join(projectRoot, "config"))
-	if err := os.Symlink(absConfig, filepath.Join(tmpdir, "config")); err != nil {
-		t.Fatalf("creating config symlink: %v", err)
-	}
-
-	overlay := filepath.Join(tmpdir, "overlay")
-	if err := os.Mkdir(overlay, 0755); err != nil {
-		t.Fatalf("creating overlay dir: %v", err)
-	}
-
-	kustomization := fmt.Sprintf(`
-resources:
-- ../config/default
-images:
-- name: controller
-  newName: %s
-  newTag: %s
-patches:
-- patch: |
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: bootc-operator-controller-manager
-      namespace: bootc-operator
-    spec:
-      template:
-        spec:
-          tolerations:
-          - key: node-role.kubernetes.io/control-plane
-            operator: Exists
-            effect: NoSchedule
-`, inClusterControllerRepo, inClusterControllerTag)
-	if err := os.WriteFile(filepath.Join(overlay, "kustomization.yaml"), []byte(kustomization), 0644); err != nil {
-		t.Fatalf("writing overlay kustomization: %v", err)
-	}
-
-	cmd := exec.Command(kubectl, "apply",
-		"--kubeconfig", kubeconfigPath,
-		"-k", overlay,
-		"--server-side",
-	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("kubectl apply failed: %v", err)
-	}
-}
-
-// waitForControllerReady waits for the controller manager Deployment to
-// have at least one ready replica.
-func waitForControllerReady(t *testing.T, c client.Client) {
-	t.Helper()
-	t.Log("Waiting for controller to be ready...")
-
-	g := NewWithT(t)
+// cleanup deletes test-scoped resources and bink nodes.
+func (e *Env) cleanup(t *testing.T) {
 	ctx := context.Background()
-	g.Eventually(func(g Gomega) {
-		var dep appsv1.Deployment
-		key := client.ObjectKey{
-			Namespace: "bootc-operator",
-			Name:      "bootc-operator-controller-manager",
+	t.Logf("Removing pools with label %s=%s...", LabelE2ETest, e.testID)
+	if err := e.Client.DeleteAllOf(ctx, &bootcv1alpha1.BootcNodePool{}, client.MatchingLabels(e.TestLabels())); err != nil {
+		t.Logf("WARNING: pool cleanup: %v", err)
+	}
+	for _, name := range e.nodes {
+		t.Logf("Removing node %q...", name)
+		if err := runBink(t, "node", "remove", name, "--force", "--cluster-name", e.clusterName); err != nil {
+			t.Logf("WARNING: failed to remove node %q: %v", name, err)
 		}
-		err := c.Get(ctx, key, &dep)
-		if apierrors.IsNotFound(err) {
-			t.Logf("  controller deployment not found yet")
-		}
-		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(dep.Status.ReadyReplicas).To(BeNumerically(">", 0))
-		t.Log("  controller is ready")
-	}).WithTimeout(3 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+	}
+}
+
+// sanitizeTestName lowercases a test name for use in k8s object names.
+// Panics if the result exceeds 63 characters (k8s label value limit).
+func sanitizeTestName(name string) string {
+	name = strings.ToLower(name)
+	if len(name) > 63 {
+		panic(fmt.Sprintf("test name %q is %d characters (max 63)", name, len(name)))
+	}
+	return name
+}
+
+// generateNodeName creates a unique node name derived from the test name.
+func (e *Env) generateNodeName(t *testing.T) string {
+	t.Helper()
+
+	b := make([]byte, 3)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("generating random suffix: %v", err)
+	}
+	return e.testID + "-" + hex.EncodeToString(b)
 }
 
 // buildClient creates a controller-runtime client from the kubeconfig
@@ -384,11 +249,7 @@ func waitForNodeReady(t *testing.T, c client.Client, nodeName string) {
 	ctx := context.Background()
 	g.Eventually(func(g Gomega) {
 		node := &corev1.Node{}
-		err := c.Get(ctx, client.ObjectKey{Name: nodeName}, node)
-		if apierrors.IsNotFound(err) {
-			t.Logf("  node %q not found yet", nodeName)
-		}
-		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(c.Get(ctx, client.ObjectKey{Name: nodeName}, node)).To(Succeed())
 		g.Expect(node.Status.Conditions).To(ContainElement(And(
 			HaveField("Type", corev1.NodeReady),
 			HaveField("Status", corev1.ConditionTrue),
@@ -401,10 +262,7 @@ func waitForNodeReady(t *testing.T, c client.Client, nodeName string) {
 func runBink(t *testing.T, args ...string) error {
 	t.Helper()
 
-	if binkPath == "" {
-		panic("runBink called before resolveBinkPath")
-	}
-	cmd := exec.Command(binkPath, args...)
+	cmd := exec.Command("bink", args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/test/util/builders.go
+++ b/test/util/builders.go
@@ -80,6 +80,16 @@ func WithDrainTimeoutSeconds(seconds int32) PoolOption {
 	}
 }
 
+// WithLabel sets a metadata label on the pool.
+func WithLabel(key, value string) PoolOption {
+	return func(pool *bootcv1alpha1.BootcNodePool) {
+		if pool.Labels == nil {
+			pool.Labels = make(map[string]string)
+		}
+		pool.Labels[key] = value
+	}
+}
+
 // WithNodeSelector sets the nodeSelector on a pool.
 func WithNodeSelector(labels map[string]string) PoolOption {
 	return func(pool *bootcv1alpha1.BootcNodePool) {


### PR DESCRIPTION
See individual commits, but the primary commit is:

---

The e2e harness previously did way more than it should: pushing the
operator image to the bink registry, and deploying the operator
manifests.

Both of those things are useful and needed outside the e2e context for
the developer flow.

Add new `deploy-bink` and `teardown-bink` targets to manage a bink
cluster. `deploy-bink` is idempotent: it starts the registry, pushes the
image, creates the cluster if needed, and applies manifests via make
deploy.

And then we can simplify `make e2e` so it just runs the tests against an
existing cluster.

The e2e iteration loop then is now: `make buildimg deploy-bink e2e`.

Future patches will rework the e2e harness Go bits.

Ref: https://github.com/jlebon/bootc-operator/issues/20
Assisted-by: Pi (Claude Opus 4.6)