### PR TITLE
 Detect external bootc status changes via fsnotify (milestone 4d)

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
@@ -32,6 +34,9 @@ func init() {
 }
 
 func main() {
+	var pollInterval time.Duration
+	flag.DurationVar(&pollInterval, "bootc-poll-interval", 5*time.Minute, "Interval for polling bootc status as a fallback to fsnotify")
+
 	opts := zap.Options{
 		Development: true,
 	}
@@ -62,17 +67,33 @@ func main() {
 		os.Exit(1)
 	}
 
+	executor := bootc.NewHostExecutor()
+
+	watcher := &daemon.StatusWatcher{
+		PollInterval: pollInterval,
+		OstreePath:    daemon.DefaultOstreePath,
+		ComposefsPath: daemon.DefaultComposefsPath,
+		Events:       make(chan event.GenericEvent, 1),
+		NodeName:     nodeName,
+		Executor:     executor,
+	}
+	if err := mgr.Add(watcher); err != nil {
+		setupLog.Error(err, "Failed to add status watcher")
+		os.Exit(1)
+	}
+
 	if err := (&daemon.BootcNodeReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		NodeName: nodeName,
-		Executor: bootc.NewHostExecutor(),
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		NodeName:      nodeName,
+		Executor:      executor,
+		StatusWatcher: watcher,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "bootcnode")
 		os.Exit(1)
 	}
 
-	setupLog.Info("Starting daemon", "node", nodeName)
+	setupLog.Info("Starting daemon", "node", nodeName, "pollInterval", pollInterval)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "Failed to run daemon")
 		os.Exit(1)

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -70,12 +70,12 @@ func main() {
 	executor := bootc.NewHostExecutor()
 
 	watcher := &daemon.StatusWatcher{
-		PollInterval: pollInterval,
+		PollInterval:  pollInterval,
 		OstreePath:    daemon.DefaultOstreePath,
 		ComposefsPath: daemon.DefaultComposefsPath,
-		Events:       make(chan event.GenericEvent, 1),
-		NodeName:     nodeName,
-		Executor:     executor,
+		Events:        make(chan event.GenericEvent, 1),
+		NodeName:      nodeName,
+		Executor:      executor,
 	}
 	if err := mgr.Add(watcher); err != nil {
 		setupLog.Error(err, "Failed to add status watcher")

--- a/internal/daemon/fake_test.go
+++ b/internal/daemon/fake_test.go
@@ -94,17 +94,6 @@ func (f *fakeExecutor) getRebooted() bool {
 	return f.rebooted
 }
 
-func (f *fakeExecutor) reset() {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.status = bootc.Status{}
-	f.statusErr = nil
-	f.stageErr = nil
-	f.stageImg = ""
-	f.stageHook = nil
-	f.rebooted = false
-}
-
 func newBootEntry(image, digest string) *bootc.BootEntry {
 	return &bootc.BootEntry{
 		Image: &bootc.ImageStatus{

--- a/internal/daemon/reconciler.go
+++ b/internal/daemon/reconciler.go
@@ -46,13 +46,14 @@ type stageOp struct {
 }
 
 // BootcNodeReconciler reconciles the BootcNode for the node this daemon
-// runs on. It reads bootc status from the host, detects image mismatches,
-// and drives updates via bootc stage.
+// runs on. It reads bootc status from the watcher's cache, detects image
+// mismatches, and drives updates via bootc stage.
 type BootcNodeReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	NodeName string
-	Executor bootc.Executor
+	Scheme        *runtime.Scheme
+	NodeName      string
+	Executor      bootc.Executor
+	StatusWatcher *StatusWatcher
 
 	inflight  stageOp
 	stageDone chan event.GenericEvent
@@ -67,6 +68,7 @@ func (r *BootcNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&bootcv1alpha1.BootcNode{}).
 		WatchesRawSource(source.Channel(r.stageDone, &handler.EnqueueRequestForObject{})).
+		WatchesRawSource(source.Channel(r.StatusWatcher.Events, &handler.EnqueueRequestForObject{})).
 		Named("bootcnode").
 		Complete(r)
 }
@@ -317,14 +319,9 @@ func (s *stageOp) run(ctx context.Context, nodeName, image string, executor boot
 }
 
 func (r *BootcNodeReconciler) populateBootcFields(ctx context.Context, bn *bootcv1alpha1.BootcNode) error {
-	data, err := r.Executor.Status(ctx)
+	status, err := r.StatusWatcher.GetStatus(ctx)
 	if err != nil {
 		return fmt.Errorf("getting bootc status: %w", err)
-	}
-
-	status, err := bootc.ParseStatus(data)
-	if err != nil {
-		return fmt.Errorf("failed to parse bootc status: %w", err)
 	}
 
 	bn.Status.Booted = convertBootEntry(status.Status.Booted)

--- a/internal/daemon/reconciler_test.go
+++ b/internal/daemon/reconciler_test.go
@@ -32,6 +32,8 @@ func TestReconcilePopulatesStatus(t *testing.T) {
 	g.SetDefaultEventuallyPollingInterval(pollInterval)
 	ctx := context.Background()
 
+	fake := newTestEnv()
+
 	v1 := "v1"
 	v2 := "v2"
 	v3 := "v3"
@@ -99,7 +101,7 @@ func TestReconcileBootcStatusError(t *testing.T) {
 	g.SetDefaultEventuallyPollingInterval(pollInterval)
 	ctx := context.Background()
 
-	resetDaemon()
+	fake := newTestEnv()
 	fake.setStatusErr(errors.New(bootcStatusErrMsg))
 
 	bn := testutil.NewNode(testNodeName, testutil.ImageDigestRefA)
@@ -126,7 +128,7 @@ func TestStagingTriggered(t *testing.T) {
 	g.SetDefaultEventuallyPollingInterval(pollInterval)
 	ctx := context.Background()
 
-	resetDaemon()
+	fake := newTestEnv()
 	fake.status = newBootcStatus(testutil.DigestA)
 
 	bn := testutil.NewNode(testNodeName, testutil.ImageDigestRefB)
@@ -163,7 +165,7 @@ func TestStagingError(t *testing.T) {
 	g.SetDefaultEventuallyPollingInterval(pollInterval)
 	ctx := context.Background()
 
-	resetDaemon()
+	fake := newTestEnv()
 	fake.status = newBootcStatus(testutil.DigestA)
 	fake.setStageErr(errors.New(stageErrMsg))
 
@@ -196,7 +198,7 @@ func TestAlreadyStaged(t *testing.T) {
 	g.SetDefaultEventuallyPollingInterval(pollInterval)
 	ctx := context.Background()
 
-	resetDaemon()
+	fake := newTestEnv()
 	fake.status = newBootcStatus(testutil.DigestA)
 	fake.status.Status.Staged = newBootEntry(testutil.ImageDigestRefB, testutil.DigestB)
 
@@ -225,7 +227,7 @@ func TestRebootingSet(t *testing.T) {
 	g.SetDefaultEventuallyPollingInterval(pollInterval)
 	ctx := context.Background()
 
-	resetDaemon()
+	fake := newTestEnv()
 	fake.status = newBootcStatus(testutil.DigestA)
 	fake.status.Status.Staged = newBootEntry(testutil.ImageDigestRefB, testutil.DigestB)
 
@@ -254,7 +256,7 @@ func TestRollback(t *testing.T) {
 	g.SetDefaultEventuallyPollingInterval(pollInterval)
 	ctx := context.Background()
 
-	resetDaemon()
+	fake := newTestEnv()
 	fake.status = newBootcStatus(testutil.DigestA)
 	fake.status.Status.Staged = newBootEntry(testutil.ImageDigestRefB, testutil.DigestB)
 
@@ -285,7 +287,7 @@ func TestCancelInflightStage(t *testing.T) {
 	g.SetDefaultEventuallyPollingInterval(pollInterval)
 	ctx := context.Background()
 
-	resetDaemon()
+	fake := newTestEnv()
 	fake.status = newBootcStatus(testutil.DigestA)
 
 	firstBlock := make(chan struct{})

--- a/internal/daemon/suite_test.go
+++ b/internal/daemon/suite_test.go
@@ -13,6 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -22,19 +23,10 @@ import (
 const testNodeName = "test-node"
 
 var (
-	testEnv    *envtest.Environment
-	k8sClient  client.Client
-	fake       *fakeExecutor
-	reconciler *BootcNodeReconciler
+	testEnv        *envtest.Environment
+	k8sClient      client.Client
+	testReconciler *BootcNodeReconciler
 )
-
-// resetDaemon resets all volatile state on the shared reconciler and
-// fake executor so each test starts from a clean slate.
-func resetDaemon() {
-	fake.reset()
-	reconciler.rebootIssued = false
-	reconciler.inflight.reset()
-}
 
 func TestMain(m *testing.M) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -61,8 +53,6 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	fake = &fakeExecutor{}
-
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 		Metrics: metricsserver.Options{
@@ -74,13 +64,23 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	reconciler = &BootcNodeReconciler{
+	fake := &fakeExecutor{}
+	testReconciler = &BootcNodeReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		NodeName: testNodeName,
 		Executor: fake,
+		StatusWatcher: &StatusWatcher{
+			Events:   make(chan event.GenericEvent, 1),
+			NodeName: testNodeName,
+			Executor: fake,
+		},
 	}
-	if err := reconciler.SetupWithManager(mgr); err != nil {
+	if err := mgr.Add(testReconciler.StatusWatcher); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to add status watcher: %v\n", err)
+		os.Exit(1)
+	}
+	if err := testReconciler.SetupWithManager(mgr); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to setup reconciler: %v\n", err)
 		os.Exit(1)
 	}
@@ -106,4 +106,19 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(code)
+}
+
+// newTestEnv creates a fresh fakeExecutor and StatusWatcher for a test,
+// wiring them into the shared reconciler. Each test gets its own cache.
+func newTestEnv() *fakeExecutor {
+	fake := &fakeExecutor{}
+	testReconciler.Executor = fake
+	testReconciler.rebootIssued = false
+	testReconciler.inflight.reset()
+	testReconciler.StatusWatcher = &StatusWatcher{
+		Events:   testReconciler.StatusWatcher.Events,
+		NodeName: testNodeName,
+		Executor: fake,
+	}
+	return fake
 }

--- a/internal/daemon/watcher.go
+++ b/internal/daemon/watcher.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+const (
+	DefaultOstreePath    = "/proc/1/root/ostree/bootc"
+	DefaultComposefsPath = "/proc/1/root/sysroot/state/deploy"
+)
+
+type StatusWatcher struct {
+	PollInterval  time.Duration
+	OstreePath    string
+	ComposefsPath string
+	Events        chan event.GenericEvent
+	NodeName      string
+	Ready         chan struct{}
+}
+
+// Start implements manager.Runnable.
+func (w *StatusWatcher) Start(ctx context.Context) error {
+	log := logf.FromContext(ctx).WithName("status-watcher")
+
+	watchPath := w.resolveWatchPath()
+
+	fsWatcher := w.setupFsnotify(log, watchPath)
+
+	closeFsWatcher := func() {
+		if fsWatcher != nil {
+			_ = fsWatcher.Close()
+			fsWatcher = nil
+		}
+	}
+	defer closeFsWatcher()
+
+	if w.PollInterval <= 0 {
+		w.PollInterval = 5 * time.Minute
+	}
+
+	ticker := time.NewTicker(w.PollInterval)
+	defer ticker.Stop()
+
+	var evCh <-chan fsnotify.Event
+	var errCh <-chan error
+	if fsWatcher != nil {
+		evCh = fsWatcher.Events
+		errCh = fsWatcher.Errors
+	}
+
+	if w.Ready != nil {
+		close(w.Ready)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev := <-evCh:
+			// ostree backend: mtime change triggers ATTRIB (Chmod).
+			// composefs backend: new deploy directory triggers Create.
+			if ev.Has(fsnotify.Chmod) || ev.Has(fsnotify.Create) {
+				log.V(1).Info("Detected bootc status change via fsnotify")
+				w.sendEvent()
+			}
+		// Tear down fsnotify so the loop continues with polling only.
+		// A broken inotify fd never delivers events again, so without this
+		// the watcher silently stops reacting to filesystem changes.
+		case err := <-errCh:
+			log.Error(err, "fsnotify error, degrading to polling only")
+			closeFsWatcher()
+			evCh = nil
+			errCh = nil
+		case <-ticker.C:
+			log.V(1).Info("Polling bootc status")
+			w.sendEvent()
+		}
+	}
+}
+
+func (w *StatusWatcher) setupFsnotify(log logr.Logger, watchPath string) *fsnotify.Watcher {
+	if watchPath == "" {
+		log.Info("No bootc paths to watch found, using polling only")
+		return nil
+	}
+
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Error(err, "Failed to create fsnotify watcher, falling back to polling")
+		return nil
+	}
+
+	if err := fsWatcher.Add(watchPath); err != nil {
+		log.Error(err, "Failed to watch path, falling back to polling", "path", watchPath)
+		_ = fsWatcher.Close()
+		return nil
+	}
+
+	log.Info("Watching path for bootc status changes", "path", watchPath)
+	return fsWatcher
+}
+
+func (w *StatusWatcher) resolveWatchPath() string {
+	if _, err := os.Stat(w.OstreePath); err == nil {
+		return w.OstreePath
+	}
+	if _, err := os.Stat(w.ComposefsPath); err == nil {
+		return w.ComposefsPath
+	}
+	return ""
+}
+
+func (w *StatusWatcher) sendEvent() {
+	ev := event.GenericEvent{
+		Object: &bootcv1alpha1.BootcNode{
+			ObjectMeta: metav1.ObjectMeta{Name: w.NodeName},
+		},
+	}
+	select {
+	case w.Events <- ev:
+	default:
+	}
+}

--- a/internal/daemon/watcher.go
+++ b/internal/daemon/watcher.go
@@ -5,6 +5,8 @@ package daemon
 import (
 	"context"
 	"os"
+	"reflect"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -13,6 +15,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	"github.com/bootc-dev/bootc-operator/internal/bootc"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
@@ -27,7 +30,45 @@ type StatusWatcher struct {
 	ComposefsPath string
 	Events        chan event.GenericEvent
 	NodeName      string
+	Executor      bootc.Executor
 	Ready         chan struct{}
+
+	mu      sync.RWMutex
+	cached  *bootc.Status
+	started bool
+}
+
+// GetStatus returns the cached bootc status when the watcher loop is
+// running (fsnotify or polling keeps the cache fresh). If the watcher
+// has not been started, it always reads fresh from the host.
+func (w *StatusWatcher) GetStatus(ctx context.Context) (*bootc.Status, error) {
+	w.mu.RLock()
+	s := w.cached
+	started := w.started
+	w.mu.RUnlock()
+	if started && s != nil {
+		return s, nil
+	}
+	s, _, err := w.refresh(ctx)
+	return s, err
+}
+
+// refresh reads bootc status from the host and updates the cache.
+// Returns the new status, if the cache has changed or an error.
+func (w *StatusWatcher) refresh(ctx context.Context) (*bootc.Status, bool, error) {
+	data, err := w.Executor.Status(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	s, err := bootc.ParseStatus(data)
+	if err != nil {
+		return nil, false, err
+	}
+	w.mu.Lock()
+	changed := !reflect.DeepEqual(s, w.cached)
+	w.cached = s
+	w.mu.Unlock()
+	return s, changed, nil
 }
 
 // Start implements manager.Runnable.
@@ -50,8 +91,18 @@ func (w *StatusWatcher) Start(ctx context.Context) error {
 		w.PollInterval = 5 * time.Minute
 	}
 
-	ticker := time.NewTicker(w.PollInterval)
-	defer ticker.Stop()
+	// Only start polling once fsnotify is unavailable.
+	var ticker *time.Ticker
+	var tickerCh <-chan time.Time
+	if fsWatcher == nil {
+		ticker = time.NewTicker(w.PollInterval)
+		tickerCh = ticker.C
+	}
+	defer func() {
+		if ticker != nil {
+			ticker.Stop()
+		}
+	}()
 
 	var evCh <-chan fsnotify.Event
 	var errCh <-chan error
@@ -59,6 +110,10 @@ func (w *StatusWatcher) Start(ctx context.Context) error {
 		evCh = fsWatcher.Events
 		errCh = fsWatcher.Errors
 	}
+
+	w.mu.Lock()
+	w.started = true
+	w.mu.Unlock()
 
 	if w.Ready != nil {
 		close(w.Ready)
@@ -73,7 +128,7 @@ func (w *StatusWatcher) Start(ctx context.Context) error {
 			// composefs backend: new deploy directory triggers Create.
 			if ev.Has(fsnotify.Chmod) || ev.Has(fsnotify.Create) {
 				log.V(1).Info("Detected bootc status change via fsnotify")
-				w.sendEvent()
+				w.refreshAndNotify(ctx, log)
 			}
 		// Tear down fsnotify so the loop continues with polling only.
 		// A broken inotify fd never delivers events again, so without this
@@ -83,11 +138,27 @@ func (w *StatusWatcher) Start(ctx context.Context) error {
 			closeFsWatcher()
 			evCh = nil
 			errCh = nil
-		case <-ticker.C:
+			ticker = time.NewTicker(w.PollInterval)
+			tickerCh = ticker.C
+		case <-tickerCh:
 			log.V(1).Info("Polling bootc status")
-			w.sendEvent()
+			w.refreshAndNotify(ctx, log)
 		}
 	}
+}
+
+// refreshAndNotify reads bootc status, updates the cache, and sends
+// an event to trigger reconciliation.
+func (w *StatusWatcher) refreshAndNotify(ctx context.Context, log logr.Logger) {
+	_, changed, err := w.refresh(ctx)
+	if err != nil {
+		log.Error(err, "Failed to refresh bootc status")
+		return
+	}
+	if !changed {
+		return
+	}
+	w.sendEvent()
 }
 
 func (w *StatusWatcher) setupFsnotify(log logr.Logger, watchPath string) *fsnotify.Watcher {

--- a/internal/daemon/watcher_test.go
+++ b/internal/daemon/watcher_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func startWatcher(t *testing.T, w *StatusWatcher) (done <-chan error, cancel context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan error, 1)
+	go func() { ch <- w.Start(ctx) }()
+	<-w.Ready
+	return ch, cancel
+}
+
+type triggerKind int
+
+const (
+	triggerNone   triggerKind = iota
+	triggerChmod              // ostree: mtime change fires ATTRIB
+	triggerCreate             // composefs: new deploy dir fires CREATE
+)
+
+func TestWatcherEvents(t *testing.T) {
+	tests := []struct {
+		name         string
+		mkOstree     bool
+		mkComposefs  bool
+		trigger      triggerKind
+		pollInterval time.Duration
+	}{
+		{
+			name:         "OstreeChmod",
+			mkOstree:     true,
+			trigger:      triggerChmod,
+			pollInterval: 10 * time.Minute,
+		},
+		{
+			name:         "ComposefsCreate",
+			mkComposefs:  true,
+			trigger:      triggerCreate,
+			pollInterval: 10 * time.Minute,
+		},
+		{
+			name:         "PollOnly",
+			pollInterval: 200 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			ostreePath := filepath.Join(dir, "bootc")
+			composefsPath := filepath.Join(dir, "deploy")
+
+			if tt.mkOstree {
+				if err := os.Mkdir(ostreePath, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.mkComposefs {
+				if err := os.Mkdir(composefsPath, 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			events := make(chan event.GenericEvent, 1)
+			w := &StatusWatcher{
+				PollInterval:  tt.pollInterval,
+				OstreePath:    ostreePath,
+				ComposefsPath: composefsPath,
+				Events:        events,
+				NodeName:      "test-node",
+				Ready:         make(chan struct{}),
+			}
+
+			done, cancel := startWatcher(t, w)
+			defer cancel()
+
+			switch tt.trigger {
+			case triggerChmod:
+				now := time.Now()
+				if err := os.Chtimes(ostreePath, now, now); err != nil {
+					t.Fatal(err)
+				}
+			case triggerCreate:
+				if err := os.Mkdir(filepath.Join(composefsPath, "new-deploy"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			select {
+			case ev := <-events:
+				if ev.Object.GetName() != "test-node" {
+					t.Errorf("expected node name test-node, got %s", ev.Object.GetName())
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for event")
+			}
+
+			cancel()
+			if err := <-done; err != nil {
+				t.Fatalf("watcher returned error: %v", err)
+			}
+		})
+	}
+}
+
+func TestWatcherShutdown(t *testing.T) {
+	dir := t.TempDir()
+	watchDir := filepath.Join(dir, "bootc")
+	if err := os.Mkdir(watchDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w := &StatusWatcher{
+		PollInterval:  10 * time.Minute,
+		OstreePath:    watchDir,
+		ComposefsPath: filepath.Join(dir, "nonexistent"),
+		Events:        make(chan event.GenericEvent, 1),
+		NodeName:      "test-node",
+		Ready:         make(chan struct{}),
+	}
+
+	done, cancel := startWatcher(t, w)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("watcher returned error on shutdown: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for watcher to shut down")
+	}
+}

--- a/internal/daemon/watcher_test.go
+++ b/internal/daemon/watcher_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	testutil "github.com/bootc-dev/bootc-operator/test/util"
 )
 
 func startWatcher(t *testing.T, w *StatusWatcher) (done <-chan error, cancel context.CancelFunc) {
@@ -19,6 +21,20 @@ func startWatcher(t *testing.T, w *StatusWatcher) (done <-chan error, cancel con
 	go func() { ch <- w.Start(ctx) }()
 	<-w.Ready
 	return ch, cancel
+}
+
+func newTestWatcher(ostreePath, composefsPath string, pollInterval time.Duration) *StatusWatcher {
+	f := &fakeExecutor{}
+	f.status = newBootcStatus(testutil.DigestA)
+	return &StatusWatcher{
+		PollInterval:  pollInterval,
+		OstreePath:    ostreePath,
+		ComposefsPath: composefsPath,
+		Events:        make(chan event.GenericEvent, 1),
+		NodeName:      "test-node",
+		Executor:      f,
+		Ready:         make(chan struct{}),
+	}
 }
 
 type triggerKind int
@@ -72,15 +88,7 @@ func TestWatcherEvents(t *testing.T) {
 				}
 			}
 
-			events := make(chan event.GenericEvent, 1)
-			w := &StatusWatcher{
-				PollInterval:  tt.pollInterval,
-				OstreePath:    ostreePath,
-				ComposefsPath: composefsPath,
-				Events:        events,
-				NodeName:      "test-node",
-				Ready:         make(chan struct{}),
-			}
+			w := newTestWatcher(ostreePath, composefsPath, tt.pollInterval)
 
 			done, cancel := startWatcher(t, w)
 			defer cancel()
@@ -98,7 +106,7 @@ func TestWatcherEvents(t *testing.T) {
 			}
 
 			select {
-			case ev := <-events:
+			case ev := <-w.Events:
 				if ev.Object.GetName() != "test-node" {
 					t.Errorf("expected node name test-node, got %s", ev.Object.GetName())
 				}
@@ -114,6 +122,72 @@ func TestWatcherEvents(t *testing.T) {
 	}
 }
 
+func TestWatcherCachesStatus(t *testing.T) {
+	dir := t.TempDir()
+	w := newTestWatcher(filepath.Join(dir, "nonexistent"), filepath.Join(dir, "nonexistent2"), 200*time.Millisecond)
+
+	done, cancel := startWatcher(t, w)
+	defer cancel()
+
+	// Wait for the poll to fire and populate the cache.
+	select {
+	case <-w.Events:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+
+	status, err := w.GetStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetStatus returned error: %v", err)
+	}
+	if status.Status.Booted == nil || status.Status.Booted.Image == nil {
+		t.Fatal("expected booted entry in cached status")
+	}
+	if status.Status.Booted.Image.ImageDigest != testutil.DigestA {
+		t.Errorf("expected digest %s, got %s", testutil.DigestA, status.Status.Booted.Image.ImageDigest)
+	}
+
+	// Change the executor's data to simulate a stale cache where
+	// fsnotify hasn't fired yet. GetStatus must still return the
+	// cached (old) value, proving it serves from cache.
+	f := w.Executor.(*fakeExecutor)
+	f.mu.Lock()
+	f.status = newBootcStatus(testutil.DigestB)
+	f.mu.Unlock()
+
+	status, err = w.GetStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetStatus returned error after executor change: %v", err)
+	}
+	if status.Status.Booted.Image.ImageDigest != testutil.DigestA {
+		t.Errorf("expected cached digest %s, got %s", testutil.DigestA, status.Status.Booted.Image.ImageDigest)
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("watcher returned error: %v", err)
+	}
+}
+
+func TestWatcherGetStatusColdCache(t *testing.T) {
+	f := &fakeExecutor{}
+	f.status = newBootcStatus(testutil.DigestA)
+
+	w := &StatusWatcher{
+		Events:   make(chan event.GenericEvent, 1),
+		NodeName: "test-node",
+		Executor: f,
+	}
+
+	status, err := w.GetStatus(context.Background())
+	if err != nil {
+		t.Fatalf("GetStatus returned error: %v", err)
+	}
+	if status.Status.Booted == nil || status.Status.Booted.Image == nil || status.Status.Booted.Image.ImageDigest != testutil.DigestA {
+		t.Fatalf("expected booted digest %s", testutil.DigestA)
+	}
+}
+
 func TestWatcherShutdown(t *testing.T) {
 	dir := t.TempDir()
 	watchDir := filepath.Join(dir, "bootc")
@@ -121,14 +195,7 @@ func TestWatcherShutdown(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w := &StatusWatcher{
-		PollInterval:  10 * time.Minute,
-		OstreePath:    watchDir,
-		ComposefsPath: filepath.Join(dir, "nonexistent"),
-		Events:        make(chan event.GenericEvent, 1),
-		NodeName:      "test-node",
-		Ready:         make(chan struct{}),
-	}
+	w := newTestWatcher(watchDir, filepath.Join(dir, "nonexistent"), 10*time.Minute)
 
 	done, cancel := startWatcher(t, w)
 	cancel()
@@ -140,5 +207,32 @@ func TestWatcherShutdown(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for watcher to shut down")
+	}
+}
+
+func TestWatcherNoPollWhenFsnotifyHealthy(t *testing.T) {
+	dir := t.TempDir()
+	ostreePath := filepath.Join(dir, "bootc")
+	if err := os.Mkdir(ostreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	w := newTestWatcher(ostreePath, filepath.Join(dir, "nonexistent"), 200*time.Millisecond)
+
+	done, cancel := startWatcher(t, w)
+	defer cancel()
+
+	// With fsnotify healthy and no filesystem events, the short poll
+	// interval should NOT fire (polling is deferred until fsnotify fails).
+	select {
+	case <-w.Events:
+		t.Fatal("received unexpected poll event while fsnotify is healthy")
+	case <-time.After(500 * time.Millisecond):
+		// expected: no events
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("watcher returned error: %v", err)
 	}
 }


### PR DESCRIPTION
Bootc changes are detected via fsnotify or via a polling mechanism.