### PR TITLE
tree: adapt for repo move from jlebon to bootc-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sysexts, etc. See the [PRD](docs/PRD.md) for more details.
 Deploy from the kustomize config:
 
 ```shell
-kubectl apply -k https://github.com/jlebon/bootc-operator//config/default
+kubectl apply -k https://github.com/bootc-dev/bootc-operator//config/default
 ```
 
 This creates the `bootc-operator` namespace and deploys the controller and

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	"github.com/jlebon/bootc-operator/internal/controller"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	"github.com/bootc-dev/bootc-operator/internal/controller"
 )
 
 var (

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -16,9 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	"github.com/jlebon/bootc-operator/internal/bootc"
-	"github.com/jlebon/bootc-operator/internal/daemon"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	"github.com/bootc-dev/bootc-operator/internal/bootc"
+	"github.com/bootc-dev/bootc-operator/internal/daemon"
 )
 
 var (

--- a/config/daemon/daemon.yaml
+++ b/config/daemon/daemon.yaml
@@ -25,7 +25,7 @@ spec:
       - name: daemon
         command:
         - daemon
-        image: ghcr.io/jlebon/bootc-operator:latest
+        image: ghcr.io/bootc-dev/bootc-operator:latest
         env:
         - name: NODE_NAME
           valueFrom:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
         args:
           - --leader-elect
           - --health-probe-bind-address=:8081
-        image: ghcr.io/jlebon/bootc-operator:latest
+        image: ghcr.io/bootc-dev/bootc-operator:latest
         name: manager
         ports:
         - containerPort: 8081

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jlebon/bootc-operator
+module github.com/bootc-dev/bootc-operator
 
 go 1.26.0
 

--- a/internal/controller/bootcnodepool_controller.go
+++ b/internal/controller/bootcnodepool_controller.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
 )
 
 // drainStatus tracks an in-progress drain goroutine for a single node.

--- a/internal/controller/crd_test.go
+++ b/internal/controller/crd_test.go
@@ -12,8 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	testutil "github.com/jlebon/bootc-operator/test/util"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	testutil "github.com/bootc-dev/bootc-operator/test/util"
 )
 
 const (

--- a/internal/controller/membership_test.go
+++ b/internal/controller/membership_test.go
@@ -14,8 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	testutil "github.com/jlebon/bootc-operator/test/util"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	testutil "github.com/bootc-dev/bootc-operator/test/util"
 )
 
 // pollInterval and pollTimeout control how long tests wait for the

--- a/internal/controller/rollout.go
+++ b/internal/controller/rollout.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
 )
 
 // rolloutState holds the classified BootcNodes for a single reconcile

--- a/internal/controller/rollout_envtest_test.go
+++ b/internal/controller/rollout_envtest_test.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	testutil "github.com/jlebon/bootc-operator/test/util"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	testutil "github.com/bootc-dev/bootc-operator/test/util"
 )
 
 // TestSimpleRollout simulates a 3-node rollout with maxUnavailable: 1. It

--- a/internal/controller/rollout_test.go
+++ b/internal/controller/rollout_test.go
@@ -10,8 +10,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	testutil "github.com/jlebon/bootc-operator/test/util"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	testutil "github.com/bootc-dev/bootc-operator/test/util"
 )
 
 func TestBuildRolloutState(t *testing.T) {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
 )
 
 var (

--- a/internal/daemon/fake_test.go
+++ b/internal/daemon/fake_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"sync"
 
-	testutil "github.com/jlebon/bootc-operator/test/util"
+	testutil "github.com/bootc-dev/bootc-operator/test/util"
 
-	"github.com/jlebon/bootc-operator/internal/bootc"
+	"github.com/bootc-dev/bootc-operator/internal/bootc"
 )
 
 type fakeExecutor struct {

--- a/internal/daemon/reconciler.go
+++ b/internal/daemon/reconciler.go
@@ -22,8 +22,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	"github.com/jlebon/bootc-operator/internal/bootc"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	"github.com/bootc-dev/bootc-operator/internal/bootc"
 )
 
 const (

--- a/internal/daemon/reconciler_test.go
+++ b/internal/daemon/reconciler_test.go
@@ -13,9 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	"github.com/jlebon/bootc-operator/internal/bootc"
-	testutil "github.com/jlebon/bootc-operator/test/util"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	"github.com/bootc-dev/bootc-operator/internal/bootc"
+	testutil "github.com/bootc-dev/bootc-operator/test/util"
 )
 
 const (

--- a/internal/daemon/suite_test.go
+++ b/internal/daemon/suite_test.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
 )
 
 const testNodeName = "test-node"

--- a/test/e2e/bootcnode_test.go
+++ b/test/e2e/bootcnode_test.go
@@ -15,8 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	"github.com/jlebon/bootc-operator/test/e2e/e2eutil"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	"github.com/bootc-dev/bootc-operator/test/e2e/e2eutil"
 )
 
 const (

--- a/test/e2e/crd_smoke_test.go
+++ b/test/e2e/crd_smoke_test.go
@@ -9,9 +9,9 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	"github.com/jlebon/bootc-operator/test/e2e/e2eutil"
-	testutil "github.com/jlebon/bootc-operator/test/util"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	"github.com/bootc-dev/bootc-operator/test/e2e/e2eutil"
+	testutil "github.com/bootc-dev/bootc-operator/test/util"
 )
 
 // TestCRDSmoke verifies CRD round-trips. We'll nuke it or enhance it with more

--- a/test/e2e/e2eutil/env.go
+++ b/test/e2e/e2eutil/env.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
-	testutil "github.com/jlebon/bootc-operator/test/util"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
+	testutil "github.com/bootc-dev/bootc-operator/test/util"
 )
 
 const (

--- a/test/util/builders.go
+++ b/test/util/builders.go
@@ -9,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	bootcv1alpha1 "github.com/jlebon/bootc-operator/api/v1alpha1"
+	bootcv1alpha1 "github.com/bootc-dev/bootc-operator/api/v1alpha1"
 )
 
 // Test fixture values. These are not helpers per se that are any use for e2e


### PR DESCRIPTION
Update the Go module path, all import paths, container image references, and the install URL in README.md to reflect the repo move from github.com/jlebon/bootc-operator to
github.com/bootc-dev/bootc-operator.

Assisted-by: Pi (Claude Opus 4.6)