### PR TITLE
tree: adapt for bink move from alicefr to bootc-dev

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
     branches: [main]
 
 env:
-  BINK_COMMIT: 8e49f3b0cf751c1b31221d93fd07fffb2842ff93
+  BINK_COMMIT: 3ddb9da3b6e33f5dadd48abdb15ed550bbfe4f31
 
 permissions: {}
 
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout bink
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          repository: alicefr/bink
+          repository: bootc-dev/bink
           ref: ${{ env.BINK_COMMIT }}
           persist-credentials: false
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CONTAINER_TOOL ?= podman
 BINK_CLUSTER_NAME ?= e2e
 KUBECONFIG_BINK ?= ./kubeconfig-$(BINK_CLUSTER_NAME)
 ARTIFACTS ?= $(abspath _output/logs)
-BINK_NODE_DISK_IMAGE ?= ghcr.io/alicefr/bink/node:v1.35-fedora-44-disk
+BINK_NODE_DISK_IMAGE ?= ghcr.io/bootc-dev/bink/node:v1.35-fedora-44-disk
 BINK_LOCAL_REGISTRY_NODE_IMAGE ?= registry.cluster.local:5000/node
 # YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
 YEAR ?= $(shell date +%Y)

--- a/config/samples/bootc_v1alpha1_bootcnodepool.yaml
+++ b/config/samples/bootc_v1alpha1_bootcnodepool.yaml
@@ -9,7 +9,7 @@ spec:
     matchLabels:
       node-role.kubernetes.io/worker: ""
   image:
-    ref: ghcr.io/alicefr/bink/node:latest
+    ref: ghcr.io/bootc-dev/bink/node:latest
   # rollout:
   #   maxUnavailable: 1                    # default
   #   paused: false                        # default

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,7 +1,7 @@
 # Bootc Operator -- Implementation Plan
 
 This document breaks the implementation into milestones.
-[bink](https://github.com/alicefr/bink) is used for e2e tests starting
+[bink](https://github.com/bootc-dev/bink) is used for e2e tests starting
 from Milestone 2 (a tool for spinning up K8s clusters backed by bootc
 VMs with a local registry).
 


### PR DESCRIPTION
The bink project moved from github.com/alicefr/bink to github.com/bootc-dev/bink. Update all repository URLs and container image references.

While we're here, bump the CI pinned commit to the latest.

Assisted-by: Pi (Claude Opus 4.6)