### PR TITLE
Cncf guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Bootc Operator Project Code of Conduct
+
+The Bootc operator project has adopted the [CNCF Community Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+All community members, contributors, and participants in the Bootc project project are expected to abide by this Code of Conduct. This includes respectful treatment of everyone, regardless of their background or identity.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,6 @@
+The current Maintainers Group for the Bootc operator Project consists of:
+
+| Name          | GitHub ID                                                      | Employer   | Responsibilities |
+| ------------- | ---------------------------------------------------------------| ---------- | ---------------- |
+| Jonathan Lebon| [jlebon](https://github.com/orgs/bootc-dev/people/jlebon)      | Red Hat    | Approver         |
+| Alice Frosi   | [alicefr](https://github.com/orgs/bootc-dev/people/alicefr)    | Red Hat    | Approver         |


### PR DESCRIPTION
This add the maintainers and code of conduct to the operator repository