### PR TITLE
makefile: Start podman socket before running bink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ e2e: ## Run e2e tests (requires: make deploy-bink). V=1 for verbose. RUN=<regex>
 		BINK_NODE_IMAGE_UPDATE_DIGEST=$$(skopeo inspect --tls-verify=false docker://localhost:5000/node:update | jq -r '.Digest') \
 		go test -timeout 20m -count=1 $(if $(V),-v) $(if $(RUN),-run $(RUN)) .
 
+.PHONY: start-socket
+start-socket:
+	systemctl start --user podman.socket
+
 ##@ Build
 
 .PHONY: build
@@ -129,7 +133,7 @@ undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.
 IMG_BINK ?= registry.cluster.local:5000/bootc-operator-e2e:latest
 
 .PHONY: seed-node-image
-seed-node-image: ## Pull the bootc node image by digest and push to the bink registry.
+seed-node-image: start-socket ## Pull the bootc node image by digest and push to the bink registry.
 	bink registry start
 	podman pull $(BINK_NODE_DISK_IMAGE)
 	bootc_img=$$(podman inspect --format '{{index .Config.Labels "bink.bootc-image"}}' $(BINK_NODE_DISK_IMAGE)) && \
@@ -165,7 +169,7 @@ gather-bink: ## Gather diagnostic logs from the bink cluster.
 		hack/gather-logs.sh $(ARTIFACTS)/gather-bink controller
 
 .PHONY: teardown-bink
-teardown-bink: ## Tear down the bink cluster.
+teardown-bink: start-socket ## Tear down the bink cluster.
 	bink cluster stop --remove-data --cluster-name $(BINK_CLUSTER_NAME)
 	rm -f $(KUBECONFIG_BINK)
 


### PR DESCRIPTION
If podman socket is not running then any and all bink commands fail, so we just start the socket ourselves before running bink commands