### PR TITLE
gha: update bink version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,6 +183,12 @@ jobs:
       - name: Load operator image
         run: podman load -i operator-image.tar
 
+      - name: Fix registries configuration
+        run: |
+          sudo tee /etc/containers/registries.conf > /dev/null <<'EOF'
+          unqualified-search-registries = ["docker.io"]
+          EOF
+
       - name: Start bink cluster
         run: make start-bink
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
     branches: [main]
 
 env:
-  BINK_COMMIT: 3ddb9da3b6e33f5dadd48abdb15ed550bbfe4f31
+  BINK_COMMIT: a38101a436b96a82698363f0d07d8dba2cf088c6
 
 permissions: {}
 


### PR DESCRIPTION
Update the bink version to include: https://github.com/bootc-dev/bink/pull/105 . This should improve the CI stability.