### PR TITLE
daemon: allow scheduling on control-plane nodes

### DIFF
--- a/config/daemon/daemon.yaml
+++ b/config/daemon/daemon.yaml
@@ -43,8 +43,6 @@ spec:
             cpu: 10m
             memory: 64Mi
       tolerations:
-      - key: node-role.kubernetes.io/control-plane
-        operator: Exists
-        effect: NoSchedule
+      - operator: Exists
       serviceAccountName: daemon
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This loosens up the toleration config on the DaemonSet so that if a BootcNodePool is created for control plane nodes, a bootc daemon pod can be scheduled on them so that their OS image can be managed.

This fixes <https://github.com/bootc-dev/bootc-operator/issues/139>
