### PR TITLE
ci: publish multi-arch operator images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # The Containerfile cross-compiles, so a non-native architecture still
+        # builds on this amd64 runner without emulation.
+        arch: [amd64, arm64]
+    env:
+      ARCH: ${{ matrix.arch }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -106,16 +114,16 @@ jobs:
           persist-credentials: false
 
       - name: Build operator image
-        run: make buildimg
+        run: make buildimg IMG="bootc-operator:dev-${ARCH}" PLATFORM="linux/${ARCH}"
 
       - name: Save operator image
-        run: podman save -o operator-image.tar bootc-operator:dev
+        run: podman save -o "operator-image-${ARCH}.tar" "bootc-operator:dev-${ARCH}"
 
       - name: Upload operator image
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: operator-image
-          path: operator-image.tar
+          name: operator-image-${{ matrix.arch }}
+          path: operator-image-${{ matrix.arch }}.tar
 
   e2e:
     runs-on: ubuntu-latest
@@ -180,10 +188,10 @@ jobs:
       - name: Download operator image
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: operator-image
+          name: operator-image-amd64
 
       - name: Load operator image
-        run: podman load -i operator-image.tar
+        run: podman load -i operator-image-amd64.tar
 
       - name: Fix registries configuration
         run: |
@@ -195,7 +203,7 @@ jobs:
         run: make start-bink
 
       - name: Deploy to bink cluster
-        run: make deploy-bink
+        run: make deploy-bink IMG=bootc-operator:dev-amd64
 
       - name: Gather deploy logs
         if: failure()
@@ -222,13 +230,29 @@ jobs:
     env:
       IMAGE: ghcr.io/${{ github.repository }}
     steps:
-      - name: Download operator image
+      - name: Download operator images
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: operator-image
+          pattern: operator-image-*
+          merge-multiple: true
 
-      - name: Load operator image
-        run: podman load -i operator-image.tar
+      - name: Assemble manifest list
+        run: |
+          shopt -s failglob
+          refs=()
+          for tar in operator-image-*.tar; do
+            arch="${tar#operator-image-}"
+            arch="${arch%.tar}"
+            podman load -i "$tar"
+            refs+=("containers-storage:localhost/bootc-operator:dev-$arch")
+          done
+          # Guard against a missing artifact silently publishing a partial
+          # manifest list, which would leave some nodes unable to pull.
+          if [[ "${#refs[@]}" -lt 2 ]]; then
+            echo "expected at least 2 architectures, got ${#refs[@]}" >&2
+            exit 1
+          fi
+          podman manifest create bootc-operator:dev "${refs[@]}"
 
       - name: Push to GHCR
         env:
@@ -239,13 +263,20 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           podman login -u "${ACTOR}" -p "${GH_TOKEN}" ghcr.io
-          podman push bootc-operator:dev "${IMAGE}":dev
-          podman push bootc-operator:dev "${IMAGE}":"${SHA}"
+          tags=(dev "${SHA}")
 
           if [[ "${REF}" == refs/tags/v* ]]; then
-            podman push bootc-operator:dev "${IMAGE}":"${REF_NAME}"
+            tags+=("${REF_NAME}")
           fi
 
           if [[ "${REF}" == refs/heads/main ]]; then
-            podman push bootc-operator:dev "${IMAGE}":latest
+            tags+=(latest)
           fi
+
+          # v2s2 keeps the per-architecture manifests in the same format as
+          # the images published before this became a manifest list, so the
+          # only change downstream sees is the added list layer.
+          for tag in "${tags[@]}"; do
+            podman manifest push --all --format v2s2 \
+              bootc-operator:dev "docker://${IMAGE}:${tag}"
+          done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,25 @@ make deploy-bink BINK_CLUSTER_NAME=dev
 ```shell
 make build           # Build all binaries (manager + daemon) to ./bin/
 make buildimg        # Build the container image (default: bootc-operator:dev)
+make buildimg-all    # Build a multi-arch manifest list (linux/amd64, linux/arm64)
 ```
 
 The `bootc-operator` container image contains both the controller and daemon
 binaries.
+
+Released images are manifest lists covering `linux/amd64` and `linux/arm64`.
+Both binaries are pure Go, so the Containerfile cross-compiles them for the
+target architecture instead of emulating the toolchain; building for a
+non-native architecture therefore costs about the same as a native build and
+needs no qemu setup. To build a single non-native image, pass `PLATFORM`:
+
+```shell
+make buildimg PLATFORM=linux/arm64
+```
+
+Note that the e2e suite remains amd64-only, because the
+[bink](https://github.com/bootc-dev/bink) node images it boots are published
+for amd64 alone.
 
 After modifying API types in `api/`, regenerate CRDs and code:
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-minimal:44 AS buildroot
+FROM --platform=$BUILDPLATFORM quay.io/fedora/fedora-minimal:44 AS buildroot
 ARG DNF_FLAGS="-y --setopt=install_weak_deps=False"
 RUN --mount=type=cache,id=dnf,target=/var/cache/libdnf5 \
     dnf install ${DNF_FLAGS} golang
@@ -9,10 +9,15 @@ COPY go.mod go.sum ./
 RUN --mount=type=cache,id=gomod,target=/root/go/pkg/mod \
     go mod download
 COPY . .
+# The buildroot stage always runs on the build host's architecture, so cross
+# compile via TARGETARCH rather than emulating the Go toolchain. Both binaries
+# are pure Go, hence CGO_ENABLED=0. The Go build cache is content addressed and
+# keyed on the target, so sharing it across architectures is safe.
+ARG TARGETARCH
 RUN --mount=type=cache,id=gomod,target=/root/go/pkg/mod \
     --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
-    go build -o manager ./cmd/controller/ && \
-    go build -o daemon ./cmd/daemon/
+    CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -o manager ./cmd/controller/ && \
+    CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -o daemon ./cmd/daemon/
 
 FROM quay.io/fedora/fedora-minimal:44
 COPY --from=builder /workspace/manager /workspace/daemon /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Image URL to use all building/pushing image targets
 IMG ?= bootc-operator:dev
 CONTAINER_TOOL ?= podman
+# Architectures published by buildimg-all. Both binaries are pure Go, so the
+# Containerfile cross-compiles rather than emulating the toolchain.
+PLATFORMS ?= linux/amd64,linux/arm64
 # Bink cluster settings. deploy-bink and e2e share the same cluster by default.
 # To use a separate dev cluster: make deploy-bink BINK_CLUSTER_NAME=dev
 BINK_CLUSTER_NAME ?= e2e
@@ -89,8 +92,12 @@ build-daemon: ## Build daemon binary.
 	go build -o bin/daemon ./cmd/daemon/
 
 .PHONY: buildimg
-buildimg: ## Build container image.
-	$(CONTAINER_TOOL) build -t $(IMG) .
+buildimg: ## Build container image. PLATFORM=linux/arm64 cross-builds for another arch.
+	$(CONTAINER_TOOL) build $(if $(PLATFORM),--platform $(PLATFORM)) -t $(IMG) .
+
+.PHONY: buildimg-all
+buildimg-all: ## Build a multi-arch manifest list image (override PLATFORMS to change).
+	$(CONTAINER_TOOL) build --platform $(PLATFORMS) --manifest $(IMG) .
 
 .PHONY: build-update-image
 build-update-image: ## Build a derived node image for update testing and push to bink registry.


### PR DESCRIPTION
Closes #144.

The published images are `linux/amd64` only, so the operator is not installable on an arm64 cluster. `config/manager/manager.yaml` and `config/daemon/daemon.yaml` both reference the same `ghcr.io/bootc-dev/bootc-operator` tag, so neither the controller Deployment nor the daemon DaemonSet has an instance to run there. The daemon cannot be made architecture independent either, since it drives `bootc` on the host through `nsenter` resolved from its own filesystem, so its container has to match the node.

Nothing in the operator is architecture specific, and the fedora-minimal base is already published for arm64, so this is build and publish plumbing rather than a code change.

## What changed

- `Containerfile` pins the buildroot stage to `$BUILDPLATFORM` and cross-compiles via `$TARGETARCH`. Both binaries are pure Go, and the final stage has no `RUN` steps, so no emulation is involved at any point — a non-native build costs about the same as a native one.
- CI builds each architecture as its own matrix leg and assembles a manifest list in the push job, rather than building a list up front. Saving a manifest list through a CI artifact is poorly supported, whereas per-architecture archives round-trip cleanly. The assemble step fails closed if an artifact is missing, since silently publishing a partial list would leave some nodes unable to pull.
- `make buildimg PLATFORM=linux/arm64` cross-builds a single image and `make buildimg-all` builds the manifest list. Plain `make buildimg` is unchanged and still builds for the host.

## Downstream compatibility

The tags under `ghcr.io/bootc-dev/bootc-operator` become manifest lists rather than single manifests, so it is worth being explicit about what existing consumers see.

The list is pushed with `--format v2s2`, which keeps the per-architecture manifests as `application/vnd.docker.distribution.manifest.v2+json`, the exact media type published today. The added list layer is therefore the only change. Pushing an OCI index instead would also have changed the child manifest media type, which seemed like unnecessary churn for a change about arm64 — happy to switch if maintainers would rather move that way, it is one flag.

Existing digest pins keep resolving, since nothing is removed from the registry. Tag consumers get platform selection for free on Docker, containerd, CRI-O and podman. Tooling that assumes a tag resolves to a single manifest, such as anything reading an image config straight off a tag, would need to handle a list; I did not find such a consumer in this repo. The bink and e2e path is untouched, because `deploy-bink` pushes a plain single-architecture image to the local registry rather than a list.

## Deliberately not included

`config/manager/manager.yaml` still carries the commented-out kubebuilder `nodeAffinity` scaffold, whose text this change makes stale: it points at a `docker-buildx` target that does not exist here, and once the image is a manifest list kubelet selects the right instance without any arch constraint. I raised it in #144 as a question rather than deciding it here, to keep this PR to one logical change. Say the word and I will drop the block or narrow it to `kubernetes.io/os: linux`.

arm64 e2e coverage is also out of scope and wants its own issue: bink publishes its node disk images for amd64 alone, and GitHub's hosted arm64 runners do not expose `/dev/kvm`, so it is a runner-infrastructure question rather than CI plumbing.

Multi-arch **node** images are out of scope too. `internal/registry/resolver.go` resolves a tag with `remote.Get`, which returns the *index* digest for a manifest list, while `internal/daemon/reconciler.go` compares that against the digest `bootc status` reports for the booted image. Every image in play today is a single manifest, so the two cannot disagree, but that may need platform-aware resolution later.

## How to validate

CI covers this end to end. Locally, verified with podman 5.6.2 on an arm64 host:

```shell
# Cross-build both directions and confirm the result is really the target arch.
make buildimg IMG=bootc-operator:amd64 PLATFORM=linux/amd64
make buildimg IMG=bootc-operator:arm64 PLATFORM=linux/arm64
podman image inspect bootc-operator:amd64 --format '{{.Architecture}}'   # amd64
podman image inspect bootc-operator:arm64 --format '{{.Architecture}}'   # arm64

# Manifest list build.
make buildimg-all IMG=bootc-operator:multi
podman manifest inspect bootc-operator:multi   # two instances

# The CI path: per-arch archive -> load -> manifest list -> push.
podman save -o op-amd64.tar bootc-operator:amd64
podman load -i op-amd64.tar                    # arch survives the round-trip
```

Pushing the assembled list to a local registry produces an `application/vnd.docker.distribution.manifest.list.v2+json` with both instances, and `podman pull --arch amd64|arm64` against it selects the matching image. Each cross-build took about 1m40s on the same host, confirming no emulation is in the path.

---

Generated-by: AI
I am knowledgeable in this problem domain and reviewed it carefully.
