### PR TITLE
Fix golines for the ci unit

### DIFF
--- a/internal/controller/bootcnodepool_controller.go
+++ b/internal/controller/bootcnodepool_controller.go
@@ -329,7 +329,10 @@ func (r *BootcNodePoolReconciler) Reconcile(
 // It removes the bootc.dev/managed label from all member nodes and deletes
 // the owned BootcNode objects, then removes the cleanup finalizer so
 // Kubernetes can complete the deletion.
-func (r *BootcNodePoolReconciler) handlePoolDeletion(ctx context.Context, pool *bootcv1alpha1.BootcNodePool) (ctrl.Result, error) {
+func (r *BootcNodePoolReconciler) handlePoolDeletion(
+	ctx context.Context,
+	pool *bootcv1alpha1.BootcNodePool,
+) (ctrl.Result, error) {
 	log := logf.FromContext(ctx).WithValues("pool", pool.Name)
 
 	if !controllerutil.ContainsFinalizer(pool, bootcv1alpha1.FinalizerPoolCleanup) {
@@ -351,7 +354,11 @@ func (r *BootcNodePoolReconciler) handlePoolDeletion(ctx context.Context, pool *
 		}
 		log.Info("Removing BootcNode for pool deletion", "node", bn.Name)
 		if err := r.removeBootcNode(ctx, bn); err != nil {
-			return ctrl.Result{}, fmt.Errorf("removing BootcNode %s during pool deletion: %w", bn.Name, err)
+			return ctrl.Result{}, fmt.Errorf(
+				"removing BootcNode %s during pool deletion: %w",
+				bn.Name,
+				err,
+			)
 		}
 	}
 

--- a/internal/controller/membership_test.go
+++ b/internal/controller/membership_test.go
@@ -242,7 +242,11 @@ func TestPoolDeletionRemovesManagedLabel(t *testing.T) {
 	}
 
 	// Create a worker pool and a separate control-plane pool.
-	workerPool := testutil.NewPool("del-workers", testImageDigestRefA, testutil.WithWorkerSelector())
+	workerPool := testutil.NewPool(
+		"del-workers",
+		testImageDigestRefA,
+		testutil.WithWorkerSelector(),
+	)
 	g.Expect(k8sClient.Create(ctx, workerPool)).To(Succeed())
 
 	cpPool := testutil.NewPool("del-control-plane", testImageDigestRefA,
@@ -286,7 +290,11 @@ func TestPoolDeletionRemovesManagedLabel(t *testing.T) {
 
 	// The worker pool itself should be fully deleted (finalizer removed).
 	g.Eventually(func() error {
-		return k8sClient.Get(ctx, client.ObjectKeyFromObject(workerPool), &bootcv1alpha1.BootcNodePool{})
+		return k8sClient.Get(
+			ctx,
+			client.ObjectKeyFromObject(workerPool),
+			&bootcv1alpha1.BootcNodePool{},
+		)
 	}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"), "worker pool should be fully deleted")
 
 	// Control-plane nodes must still carry the managed label — their pool was not deleted.
@@ -299,8 +307,9 @@ func TestPoolDeletionRemovesManagedLabel(t *testing.T) {
 
 	// Control-plane BootcNodes must still exist.
 	for _, node := range controlPlaneNodes {
-		g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: node.Name}, &bootcv1alpha1.BootcNode{})).To(Succeed(),
-			"BootcNode %s should still exist", node.Name)
+		g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: node.Name}, &bootcv1alpha1.BootcNode{})).
+			To(Succeed(),
+				"BootcNode %s should still exist", node.Name)
 	}
 }
 

--- a/internal/daemon/reconciler.go
+++ b/internal/daemon/reconciler.go
@@ -5,10 +5,11 @@ package daemon
 import (
 	"context"
 	"fmt"
-	"github.com/distribution/reference"
 	"reflect"
 	"sync"
 	"time"
+
+	"github.com/distribution/reference"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
Run `make go-lines-fix` and fix the formatting.